### PR TITLE
feat(nfc-payments): settle NFC payments through SGT

### DIFF
--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -232,10 +232,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
     let storedTransaction: Transaction | null = null;
     mockTransactionsRepository = {
       create: jest.fn().mockImplementation(async (tx: Transaction) => {
-        storedTransaction = new Transaction({
-          ...tx,
-          amount: tx.amount * 0.01,
-        });
+        storedTransaction = new Transaction(tx);
         return storedTransaction;
       }),
       updateStatus: jest.fn().mockImplementation(
@@ -413,7 +410,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       expect(mockRedis.eval).toHaveBeenCalled();
     });
 
-    it('should keep TR002 aligned with QR semantics (approved=true)', async () => {
+    it('should approve transaction when SGT returns TR002', async () => {
       mockPaymentProcessor.processPayment.mockImplementationOnce(
         async (transactionId: string) => ({
           success: true,

--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -122,7 +122,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
   let mockRedis: { eval: jest.Mock };
   let mockTerminalService: Partial<jest.Mocked<TerminalService>>;
   let mockConfigService: Partial<jest.Mocked<ConfigService>>;
-  let mockTransactionsRepository: { create: jest.Mock };
+  let mockTransactionsRepository: { create: jest.Mock; updateStatus: jest.Mock };
   let mockPaymentProcessor: { processPayment: jest.Mock };
 
   // Use the real TLV codec for building test payloads
@@ -229,8 +229,30 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       get: jest.fn().mockReturnValue('app_'),
     };
 
+    let storedTransaction: Transaction | null = null;
     mockTransactionsRepository = {
-      create: jest.fn().mockImplementation(async (tx: Transaction) => tx),
+      create: jest.fn().mockImplementation(async (tx: Transaction) => {
+        storedTransaction = new Transaction({
+          ...tx,
+          amount: tx.amount * 0.01,
+        });
+        return storedTransaction;
+      }),
+      updateStatus: jest.fn().mockImplementation(
+        async (
+          id: string,
+          status: TransactionStatus,
+          updates?: Record<string, any>,
+        ) => {
+          storedTransaction = new Transaction({
+            ...(storedTransaction ?? {}),
+            id,
+            status,
+            ...updates,
+          });
+          return storedTransaction;
+        },
+      ),
     };
 
     mockPaymentProcessor = {
@@ -308,11 +330,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
     it('should approve a valid payment with correct signature, counter, and amount', async () => {
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(true);
       expect(result.txId).toBeDefined();
@@ -344,7 +369,11 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         'tenant-001',
         expect.any(String),
         tokenData.cardId,
-        tokenData.amount,
+        tokenData.amount * 0.01,
+      );
+      expect(mockTransactionsRepository.updateStatus).toHaveBeenCalledWith(
+        persisted.id,
+        TransactionStatus.PROCESSING,
       );
 
       expect(result.approved).toBe(true);
@@ -384,6 +413,33 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       expect(mockRedis.eval).toHaveBeenCalled();
     });
 
+    it('should keep TR002 aligned with QR semantics (approved=true)', async () => {
+      mockPaymentProcessor.processPayment.mockImplementationOnce(
+        async (transactionId: string) => ({
+          success: true,
+          status: TransactionStatus.SUCCESS,
+          transferCode: 'TR002',
+          isoResponseCode: '00',
+          updatedTransaction: new Transaction({
+            id: transactionId,
+            status: TransactionStatus.SUCCESS,
+            sgtTransferCode: 'TR002',
+            sgtIsoResponseCode: '00',
+          }),
+        }),
+      );
+
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+      const result = await service.authorizePayment(
+        { signedPayload, amount: tokenData.amount, currency: tokenData.currency },
+        'oauth-client-1',
+      );
+
+      expect(result.approved).toBe(true);
+      expect((result as any).transferCode).toBe('TR002');
+      expect((result as any).status).toBe(TransactionStatus.SUCCESS);
+    });
+
     it('should return failure response when SGT processor throws (unreachable)', async () => {
       mockPaymentProcessor.processPayment.mockRejectedValueOnce(
         new Error('ECONNREFUSED'),
@@ -399,17 +455,25 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('SGT_UNREACHABLE');
       expect((result as any).status).toBe(TransactionStatus.FAILED);
+      expect(mockTransactionsRepository.updateStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        TransactionStatus.FAILED,
+        expect.objectContaining({ sgtTransferCode: 'SGT_UNREACHABLE' }),
+      );
     });
 
     it('should reject when session not found', async () => {
       mockPrepareService.getSession!.mockResolvedValueOnce(null);
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('SESSION_NOT_FOUND');
@@ -419,11 +483,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       mockEcdsaService.verify.mockReturnValueOnce(false);
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('INVALID_SIGNATURE');
@@ -450,11 +517,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       });
       const { signedPayload, tokenData } = buildValidSignedPayload({ counter: 3 });
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('COUNTER_TOO_LOW');
@@ -468,11 +538,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       });
       const { signedPayload, tokenData } = buildValidSignedPayload({ counter: 20 });
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('COUNTER_BEYOND_WINDOW');
@@ -483,11 +556,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         serverTimestamp: Date.now() - 400000, // > 5 min ago
       });
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('TOKEN_EXPIRED');
@@ -496,11 +572,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
     it('should reject when amount does not match', async () => {
       const { signedPayload, tokenData } = buildValidSignedPayload({ amount: 1000 });
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: 2000, // POS sends different amount
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: 2000, // POS sends different amount
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('AMOUNT_MISMATCH');
@@ -510,11 +589,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       mockRedis.eval.mockResolvedValueOnce(0);
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('NONCE_ALREADY_USED');
@@ -524,6 +606,24 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       mockEnrollmentService.getEnrollment!.mockResolvedValueOnce(null);
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
+
+      expect(result.approved).toBe(false);
+      expect(result.reason).toBe('CARD_NOT_ENROLLED');
+    });
+
+    // ── Terminal validation tests (Slice 5) ──────────────────────────
+
+    it('should reject with CLIENT_ID_REQUIRED when OAuth client id is missing', async () => {
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+
       const result = await service.authorizePayment({
         signedPayload,
         amount: tokenData.amount,
@@ -531,10 +631,10 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       });
 
       expect(result.approved).toBe(false);
-      expect(result.reason).toBe('CARD_NOT_ENROLLED');
+      expect(result.reason).toBe('CLIENT_ID_REQUIRED');
+      expect(mockTransactionsRepository.create).not.toHaveBeenCalled();
+      expect(mockPaymentProcessor.processPayment).not.toHaveBeenCalled();
     });
-
-    // ── Terminal validation tests (Slice 5) ──────────────────────────
 
     it('should reject with TERMINAL_NOT_FOUND when clientId has no terminal', async () => {
       mockTerminalService.findByOAuthClientId!.mockResolvedValueOnce(null);
@@ -619,11 +719,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       const warnSpy = jest.spyOn(Logger.prototype, 'warn');
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       const sigDebugCalls = warnSpy.mock.calls.filter(
         (args) => typeof args[0] === 'string' && args[0].includes('SIG-DEBUG'),
@@ -640,11 +743,14 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       });
       const { signedPayload, tokenData } = buildValidSignedPayload();
 
-      const result = await service.authorizePayment({
-        signedPayload,
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-      });
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
 
       expect(result.approved).toBe(true);
       expect(result.reason).toBe('ALREADY_PROCESSED');

--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -29,6 +29,10 @@ import type { IEcdsaSignaturePort } from '../domain/ports/ecdsa-signature.port';
 import type { NfcEnrollmentEntity } from '../domain/ports/nfc-enrollment-repository.port';
 import { Result } from 'src/common/types/result.type';
 import { TlvCodecAdapter } from '../infrastructure/adapters/tlv-codec.adapter';
+import { TransactionsRepository } from '../../transactions/infrastructure/adapters/transactions.repository';
+import { TransactionPaymentProcessor } from '../../transactions/application/services/transaction-payment.processor';
+import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
+import { NfcTransactionBuilder } from './nfc-transaction.builder';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -118,6 +122,8 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
   let mockRedis: { eval: jest.Mock };
   let mockTerminalService: Partial<jest.Mocked<TerminalService>>;
   let mockConfigService: Partial<jest.Mocked<ConfigService>>;
+  let mockTransactionsRepository: { create: jest.Mock };
+  let mockPaymentProcessor: { processPayment: jest.Mock };
 
   // Use the real TLV codec for building test payloads
   const realCodec = new TlvCodecAdapter();
@@ -223,6 +229,27 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       get: jest.fn().mockReturnValue('app_'),
     };
 
+    mockTransactionsRepository = {
+      create: jest.fn().mockImplementation(async (tx: Transaction) => tx),
+    };
+
+    mockPaymentProcessor = {
+      processPayment: jest.fn().mockImplementation(
+        async (transactionId: string) => ({
+          success: true,
+          status: TransactionStatus.SUCCESS,
+          transferCode: 'TR000',
+          isoResponseCode: '00',
+          updatedTransaction: new Transaction({
+            id: transactionId,
+            status: TransactionStatus.SUCCESS,
+            sgtTransferCode: 'TR000',
+            sgtIsoResponseCode: '00',
+          }),
+        }),
+      ),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         NfcAuthorizationService,
@@ -262,6 +289,15 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
           provide: ConfigService,
           useValue: mockConfigService,
         },
+        {
+          provide: TransactionsRepository,
+          useValue: mockTransactionsRepository,
+        },
+        {
+          provide: TransactionPaymentProcessor,
+          useValue: mockPaymentProcessor,
+        },
+        NfcTransactionBuilder,
       ],
     }).compile();
 
@@ -282,6 +318,87 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       expect(result.txId).toBeDefined();
       expect(result.amount).toBe(tokenData.amount);
       expect(result.currency).toBe(tokenData.currency);
+    });
+
+    it('should persist Transaction and dispatch to SGT, returning transferCode/status on success', async () => {
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+
+      const result = await service.authorizePayment(
+        {
+          signedPayload,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+        },
+        'oauth-client-1',
+      );
+
+      expect(mockTransactionsRepository.create).toHaveBeenCalledTimes(1);
+      const persisted = mockTransactionsRepository.create.mock.calls[0][0] as Transaction;
+      expect(persisted.tenantId).toBe('tenant-001');
+      expect(persisted.cardId).toBe(tokenData.cardId);
+      expect(persisted.amount).toBe(tokenData.amount);
+      expect(persisted.intentId).toBe(tokenData.sessionId);
+
+      expect(mockPaymentProcessor.processPayment).toHaveBeenCalledWith(
+        persisted.id,
+        'tenant-001',
+        expect.any(String),
+        tokenData.cardId,
+        tokenData.amount,
+      );
+
+      expect(result.approved).toBe(true);
+      expect(result.txId).toBe(persisted.id);
+      expect((result as any).transferCode).toBe('TR000');
+      expect((result as any).status).toBe(TransactionStatus.SUCCESS);
+    });
+
+    it('should propagate SGT rejection (TR001) as approved=false with isoResponseCode', async () => {
+      mockPaymentProcessor.processPayment.mockImplementationOnce(
+        async (transactionId: string) => ({
+          success: false,
+          status: TransactionStatus.FAILED,
+          transferCode: 'TR001',
+          isoResponseCode: '51',
+          updatedTransaction: new Transaction({
+            id: transactionId,
+            status: TransactionStatus.FAILED,
+            sgtTransferCode: 'TR001',
+            sgtIsoResponseCode: '51',
+          }),
+        }),
+      );
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+
+      const result = await service.authorizePayment(
+        { signedPayload, amount: tokenData.amount, currency: tokenData.currency },
+        'oauth-client-1',
+      );
+
+      expect(mockTransactionsRepository.create).toHaveBeenCalledTimes(1);
+      expect(result.approved).toBe(false);
+      expect((result as any).transferCode).toBe('TR001');
+      expect((result as any).isoResponseCode).toBe('51');
+      expect((result as any).status).toBe(TransactionStatus.FAILED);
+      // Nonce/counter must remain consumed (no rollback)
+      expect(mockRedis.eval).toHaveBeenCalled();
+    });
+
+    it('should return failure response when SGT processor throws (unreachable)', async () => {
+      mockPaymentProcessor.processPayment.mockRejectedValueOnce(
+        new Error('ECONNREFUSED'),
+      );
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+
+      const result = await service.authorizePayment(
+        { signedPayload, amount: tokenData.amount, currency: tokenData.currency },
+        'oauth-client-1',
+      );
+
+      expect(mockTransactionsRepository.create).toHaveBeenCalledTimes(1);
+      expect(result.approved).toBe(false);
+      expect(result.reason).toBe('SGT_UNREACHABLE');
+      expect((result as any).status).toBe(TransactionStatus.FAILED);
     });
 
     it('should reject when session not found', async () => {
@@ -310,6 +427,19 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
 
       expect(result.approved).toBe(false);
       expect(result.reason).toBe('INVALID_SIGNATURE');
+    });
+
+    it('should NOT persist a Transaction or call SGT when signature is invalid', async () => {
+      mockEcdsaService.verify.mockReturnValueOnce(false);
+      const { signedPayload, tokenData } = buildValidSignedPayload();
+
+      await service.authorizePayment(
+        { signedPayload, amount: tokenData.amount, currency: tokenData.currency },
+        'oauth-client-1',
+      );
+
+      expect(mockTransactionsRepository.create).not.toHaveBeenCalled();
+      expect(mockPaymentProcessor.processPayment).not.toHaveBeenCalled();
     });
 
     it('should reject when counter is too low (replay)', async () => {

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -224,6 +224,8 @@ export class NfcAuthorizationService {
     });
 
     let persisted: Awaited<ReturnType<TransactionsRepository['create']>>;
+    let authorizationResult: AuthorizationResult | null = null;
+    let processingError: unknown;
 
     try {
       persisted = await this.transactionsRepository.create(transaction);
@@ -246,7 +248,7 @@ export class NfcAuthorizationService {
           processPaymentArgs[4],
         );
 
-        return {
+        authorizationResult = {
           approved: paymentResult.success,
           txId: persisted.id,
           amount: tokenData.amount,
@@ -268,7 +270,7 @@ export class NfcAuthorizationService {
           { processedAt: new Date(), sgtTransferCode: 'SGT_UNREACHABLE' },
         );
 
-        return {
+        authorizationResult = {
           approved: false,
           txId: persisted.id,
           reason: 'SGT_UNREACHABLE',
@@ -279,19 +281,49 @@ export class NfcAuthorizationService {
           ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
         };
       }
+    } catch (err) {
+      processingError = err;
     } finally {
       const [sessionMarkedResult, enrollmentCounterResult] = await Promise.allSettled([
         this.prepareService.markSessionUsed(tokenData.sessionId),
         this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter),
       ]);
 
-      if (sessionMarkedResult.status === 'rejected') {
-        throw sessionMarkedResult.reason;
-      }
-      if (enrollmentCounterResult.status === 'rejected') {
-        throw enrollmentCounterResult.reason;
+      const finalizationError =
+        sessionMarkedResult.status === 'rejected'
+          ? {
+              stage: 'markSessionUsed',
+              reason: sessionMarkedResult.reason,
+            }
+          : enrollmentCounterResult.status === 'rejected'
+            ? {
+                stage: 'updateEnrollmentCounter',
+                reason: enrollmentCounterResult.reason,
+              }
+            : null;
+
+      if (finalizationError) {
+        if (processingError) {
+          this.logger.error(
+            `NFC finalization failed at ${finalizationError.stage} after processing error: ${
+              (finalizationError.reason as Error).message
+            }`,
+          );
+          throw processingError;
+        }
+        throw finalizationError.reason;
       }
     }
+
+    if (processingError) {
+      throw processingError;
+    }
+
+    if (!authorizationResult) {
+      throw new Error('NFC authorization finished without a result');
+    }
+
+    return authorizationResult;
   }
 
   private async consumeNonceAtomically(sessionId: string): Promise<boolean> {

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -9,7 +9,6 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { InjectRedis } from '@nestjs-modules/ioredis';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
-import * as crypto from 'crypto';
 
 import {
   NFC_PAYMENT_INJECTION_TOKENS,
@@ -118,24 +117,26 @@ export class NfcAuthorizationService {
       return this.getIdempotentResult(tokenData.sessionId);
     }
 
-    // Step 2b: Terminal lookup (when clientId is provided from OAuth token)
+    // Step 2b: Terminal lookup (required to derive tenant from OAuth clientId)
     let terminal: Awaited<ReturnType<TerminalService['findByOAuthClientId']>> = null;
-    if (clientId) {
-      terminal = await this.terminalService.findByOAuthClientId(clientId);
-      if (!terminal) {
-        return { approved: false, reason: 'TERMINAL_NOT_FOUND' };
-      }
-      if (terminal.status === TerminalStatus.SUSPENDED) {
-        return { approved: false, reason: 'TERMINAL_SUSPENDED' };
-      }
-      if (terminal.status === TerminalStatus.REVOKED) {
-        return { approved: false, reason: 'TERMINAL_REVOKED' };
-      }
+    if (!clientId) {
+      return { approved: false, reason: 'CLIENT_ID_REQUIRED' };
+    }
 
-      // Step 2c: Capability check
-      if (!terminal.capabilities.includes(TerminalCapability.NFC)) {
-        return { approved: false, reason: 'TERMINAL_MISSING_CAPABILITY' };
-      }
+    terminal = await this.terminalService.findByOAuthClientId(clientId);
+    if (!terminal) {
+      return { approved: false, reason: 'TERMINAL_NOT_FOUND' };
+    }
+    if (terminal.status === TerminalStatus.SUSPENDED) {
+      return { approved: false, reason: 'TERMINAL_SUSPENDED' };
+    }
+    if (terminal.status === TerminalStatus.REVOKED) {
+      return { approved: false, reason: 'TERMINAL_REVOKED' };
+    }
+
+    // Step 2c: Capability check
+    if (!terminal.capabilities.includes(TerminalCapability.NFC)) {
+      return { approved: false, reason: 'TERMINAL_MISSING_CAPABILITY' };
     }
 
     // Step 3: Get enrollment and root seed from Vault
@@ -221,45 +222,76 @@ export class NfcAuthorizationService {
       enrollment,
       terminal,
     });
-    const persisted = await this.transactionsRepository.create(transaction);
-    let paymentResult;
+
+    let persisted: Awaited<ReturnType<TransactionsRepository['create']>>;
+
     try {
-      paymentResult = await this.paymentProcessor.processPayment(...processPaymentArgs);
-    } catch (err) {
-      this.logger.error(
-        `SGT dispatch failed for txId=${persisted.id}: ${(err as Error).message}`,
+      persisted = await this.transactionsRepository.create(transaction);
+      const processingTransaction = await this.transactionsRepository.updateStatus(
+        persisted.id,
+        TransactionStatus.PROCESSING,
       );
-      await this.prepareService.markSessionUsed(tokenData.sessionId);
-      await this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter);
-      return {
-        approved: false,
-        txId: persisted.id,
-        reason: 'SGT_UNREACHABLE',
-        amount: tokenData.amount,
-        currency: tokenData.currency,
-        sessionId: tokenData.sessionId,
-        status: TransactionStatus.FAILED,
-        ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
-      };
+      if (!processingTransaction) {
+        throw new Error(`Transaction not found after status update: ${persisted.id}`);
+      }
+      if (!processingTransaction.cardId) {
+        throw new Error(`Transaction missing cardId: ${persisted.id}`);
+      }
+      try {
+        const paymentResult = await this.paymentProcessor.processPayment(
+          processingTransaction.id,
+          processingTransaction.tenantId,
+          processingTransaction.customerId,
+          processingTransaction.cardId,
+          processPaymentArgs[4],
+        );
+
+        return {
+          approved: paymentResult.success,
+          txId: persisted.id,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+          sessionId: tokenData.sessionId,
+          transferCode: paymentResult.transferCode,
+          isoResponseCode: paymentResult.isoResponseCode,
+          status: paymentResult.status,
+          ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
+        };
+      } catch (err) {
+        this.logger.error(
+          `SGT dispatch failed for txId=${persisted.id}: ${(err as Error).message}`,
+        );
+
+        await this.transactionsRepository.updateStatus(
+          persisted.id,
+          TransactionStatus.FAILED,
+          { processedAt: new Date(), sgtTransferCode: 'SGT_UNREACHABLE' },
+        );
+
+        return {
+          approved: false,
+          txId: persisted.id,
+          reason: 'SGT_UNREACHABLE',
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+          sessionId: tokenData.sessionId,
+          status: TransactionStatus.FAILED,
+          ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
+        };
+      }
+    } finally {
+      const [sessionMarkedResult, enrollmentCounterResult] = await Promise.allSettled([
+        this.prepareService.markSessionUsed(tokenData.sessionId),
+        this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter),
+      ]);
+
+      if (sessionMarkedResult.status === 'rejected') {
+        throw sessionMarkedResult.reason;
+      }
+      if (enrollmentCounterResult.status === 'rejected') {
+        throw enrollmentCounterResult.reason;
+      }
     }
-
-    // Mark session as used in prepare service
-    await this.prepareService.markSessionUsed(tokenData.sessionId);
-
-    // Update enrollment counter
-    await this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter);
-
-    return {
-      approved: paymentResult.success,
-      txId: persisted.id,
-      amount: tokenData.amount,
-      currency: tokenData.currency,
-      sessionId: tokenData.sessionId,
-      transferCode: paymentResult.transferCode,
-      isoResponseCode: paymentResult.isoResponseCode,
-      status: paymentResult.status,
-      ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
-    };
   }
 
   private async consumeNonceAtomically(sessionId: string): Promise<boolean> {

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -25,6 +25,10 @@ import { VaultHttpAdapter } from '../../vault/infrastructure/adapters/vault-http
 import { AuthorizePaymentRequestDto } from '../dto/authorize-payment-request.dto';
 import { TerminalService } from '../../terminals/application/terminal.service';
 import { TerminalStatus, TerminalCapability } from '../../terminals/domain/constants/terminal.constants';
+import { TransactionsRepository } from '../../transactions/infrastructure/adapters/transactions.repository';
+import { TransactionPaymentProcessor } from '../../transactions/application/services/transaction-payment.processor';
+import { TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
+import { NfcTransactionBuilder } from './nfc-transaction.builder';
 
 export interface TokenData {
   cardId: string;
@@ -47,6 +51,9 @@ export interface AuthorizationResult {
   tenantId?: string;
   terminalId?: string;
   sessionId?: string;
+  transferCode?: string;
+  isoResponseCode?: string;
+  status?: TransactionStatus;
 }
 
 /** Lua script for atomic nonce consumption */
@@ -88,6 +95,9 @@ export class NfcAuthorizationService {
     private readonly terminalService: TerminalService,
     @InjectRedis() private readonly redis: Redis,
     private readonly configService: ConfigService,
+    private readonly transactionsRepository: TransactionsRepository,
+    private readonly paymentProcessor: TransactionPaymentProcessor,
+    private readonly transactionBuilder: NfcTransactionBuilder,
   ) {}
 
   async authorizePayment(
@@ -205,8 +215,33 @@ export class NfcAuthorizationService {
 
     // Step 10: Balance check placeholder (deferred to integration)
 
-    // Step 11: Create transaction record
-    const txId = crypto.randomUUID();
+    // Step 11: Persist Transaction and dispatch to SGT (reuses QR settlement pipeline)
+    const { transaction, processPaymentArgs } = this.transactionBuilder.build({
+      tokenData,
+      enrollment,
+      terminal,
+    });
+    const persisted = await this.transactionsRepository.create(transaction);
+    let paymentResult;
+    try {
+      paymentResult = await this.paymentProcessor.processPayment(...processPaymentArgs);
+    } catch (err) {
+      this.logger.error(
+        `SGT dispatch failed for txId=${persisted.id}: ${(err as Error).message}`,
+      );
+      await this.prepareService.markSessionUsed(tokenData.sessionId);
+      await this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter);
+      return {
+        approved: false,
+        txId: persisted.id,
+        reason: 'SGT_UNREACHABLE',
+        amount: tokenData.amount,
+        currency: tokenData.currency,
+        sessionId: tokenData.sessionId,
+        status: TransactionStatus.FAILED,
+        ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
+      };
+    }
 
     // Mark session as used in prepare service
     await this.prepareService.markSessionUsed(tokenData.sessionId);
@@ -215,11 +250,14 @@ export class NfcAuthorizationService {
     await this.updateEnrollmentCounter(tokenData.cardId, tokenData.counter);
 
     return {
-      approved: true,
-      txId,
+      approved: paymentResult.success,
+      txId: persisted.id,
       amount: tokenData.amount,
       currency: tokenData.currency,
       sessionId: tokenData.sessionId,
+      transferCode: paymentResult.transferCode,
+      isoResponseCode: paymentResult.isoResponseCode,
+      status: paymentResult.status,
       ...(terminal && { tenantId: terminal.tenantId, terminalId: terminal.terminalId }),
     };
   }

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit Tests: NfcTransactionBuilder
+ *
+ * Pure mapping from authorization context to Transaction + processPayment args.
+ * No I/O, no DI — just data shaping.
+ */
+
+import { NfcTransactionBuilder } from './nfc-transaction.builder';
+import { TokenData } from './nfc-authorization.service';
+import { TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
+import type { TerminalEntity } from '../../terminals/domain/ports/terminal-repository.port';
+import type { NfcEnrollmentEntity } from '../domain/ports/nfc-enrollment-repository.port';
+import { TerminalCapability, TerminalStatus } from '../../terminals/domain/constants/terminal.constants';
+
+describe('NfcTransactionBuilder', () => {
+  const builder = new NfcTransactionBuilder();
+
+  const tokenData: TokenData = {
+    cardId: 'card-001',
+    amount: 1500,
+    currency: 'USD',
+    posId: 'pos-1',
+    txRef: 'tx-ref-1',
+    nonce: 'aabbccdd',
+    counter: 1,
+    serverTimestamp: Date.now(),
+    sessionId: 'session-uuid-1',
+  };
+
+  const enrollment: NfcEnrollmentEntity = {
+    id: 'enrollment-id',
+    cardId: 'card-001',
+    userId: 'user-1',
+    devicePublicKey: 'pk',
+    serverPublicKey: 'spk',
+    vaultKeyPath: 'vault/path',
+    counter: 0,
+    status: 'active',
+  };
+
+  const terminal: TerminalEntity = {
+    terminalId: 'term-001',
+    tenantId: 'tenant-001',
+    name: 'POS',
+    type: 'physical_pos',
+    capabilities: [TerminalCapability.NFC],
+    status: TerminalStatus.ACTIVE,
+    oauthClientId: 'oauth-client-1',
+    createdBy: 'admin',
+  };
+
+  it('builds a Transaction in NEW status with intentId equal to sessionId', () => {
+    const { transaction } = builder.build({ tokenData, enrollment, terminal });
+
+    expect(transaction.status).toBe(TransactionStatus.NEW);
+    expect(transaction.intentId).toBe(tokenData.sessionId);
+  });
+
+  it('maps cardId, amount, customerId from enrollment, tenantId from terminal', () => {
+    const { transaction } = builder.build({ tokenData, enrollment, terminal });
+
+    expect(transaction.cardId).toBe(tokenData.cardId);
+    expect(transaction.amount).toBe(tokenData.amount);
+    expect(transaction.customerId).toBe(enrollment.userId);
+    expect(transaction.tenantId).toBe(terminal.tenantId);
+  });
+
+  it('produces processPayment args matching the persisted transaction', () => {
+    const { transaction, processPaymentArgs } = builder.build({
+      tokenData,
+      enrollment,
+      terminal,
+    });
+
+    expect(processPaymentArgs).toEqual([
+      transaction.id,
+      transaction.tenantId,
+      enrollment.userId,
+      tokenData.cardId,
+      tokenData.amount,
+    ]);
+  });
+
+  it('falls back to empty tenantId when terminal is null (legacy callers)', () => {
+    const { transaction } = builder.build({ tokenData, enrollment, terminal: null });
+
+    expect(transaction.tenantId).toBe('');
+  });
+});

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
@@ -54,6 +54,8 @@ describe('NfcTransactionBuilder', () => {
 
     expect(transaction.status).toBe(TransactionStatus.NEW);
     expect(transaction.intentId).toBe(tokenData.sessionId);
+    expect(transaction.no).toBeGreaterThan(0);
+    expect(transaction.expiresAt.getTime()).toBeGreaterThan(Date.now());
   });
 
   it('maps cardId, amount, customerId from enrollment, tenantId from terminal', () => {
@@ -77,13 +79,13 @@ describe('NfcTransactionBuilder', () => {
       transaction.tenantId,
       enrollment.userId,
       tokenData.cardId,
-      tokenData.amount,
+      tokenData.amount * 0.01,
     ]);
   });
 
-  it('falls back to empty tenantId when terminal is null (legacy callers)', () => {
-    const { transaction } = builder.build({ tokenData, enrollment, terminal: null });
-
-    expect(transaction.tenantId).toBe('');
+  it('throws when terminal is missing tenantId', () => {
+    expect(() =>
+      builder.build({ tokenData, enrollment, terminal: null as unknown as TerminalEntity }),
+    ).toThrow('Cannot build NFC transaction without a tenantId');
   });
 });

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { createHash } from 'crypto';
 
 import { TokenData } from './nfc-authorization.service';
 import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
@@ -8,7 +9,7 @@ import type { NfcEnrollmentEntity } from '../domain/ports/nfc-enrollment-reposit
 export interface NfcTransactionBuildInput {
   tokenData: TokenData;
   enrollment: NfcEnrollmentEntity;
-  terminal: TerminalEntity | null;
+  terminal: TerminalEntity;
 }
 
 export type ProcessPaymentArgs = [
@@ -26,15 +27,46 @@ export interface NfcTransactionBuildResult {
 
 @Injectable()
 export class NfcTransactionBuilder {
+  private static lastTransactionNo = 0;
+  private static readonly TRANSACTION_TTL_MINUTES = 15;
+
+  private nextTransactionNo(): number {
+    const now = Date.now();
+    NfcTransactionBuilder.lastTransactionNo = Math.max(
+      now,
+      NfcTransactionBuilder.lastTransactionNo + 1,
+    );
+
+    return NfcTransactionBuilder.lastTransactionNo;
+  }
+
+  private buildExpiresAt(ttlMinutes: number): Date {
+    return new Date(Date.now() + ttlMinutes * 60 * 1000);
+  }
+
   build(input: NfcTransactionBuildInput): NfcTransactionBuildResult {
     const { tokenData, enrollment, terminal } = input;
+    if (!terminal?.tenantId) {
+      throw new Error('Cannot build NFC transaction without a tenantId');
+    }
+
+    const ttlMinutes = NfcTransactionBuilder.TRANSACTION_TTL_MINUTES;
+    const signature = createHash('sha256')
+      .update(`${tokenData.sessionId}:${tokenData.txRef}:${tokenData.amount}`)
+      .digest('hex');
 
     const transaction = new Transaction({
-      tenantId: terminal?.tenantId ?? '',
+      no: this.nextTransactionNo(),
+      ref: tokenData.txRef || `nfc-${tokenData.sessionId}`,
+      tenantId: terminal.tenantId,
+      tenantName: terminal.name || terminal.tenantId,
       customerId: enrollment.userId,
       cardId: tokenData.cardId,
       amount: tokenData.amount,
       intentId: tokenData.sessionId,
+      ttlMinutes,
+      expiresAt: this.buildExpiresAt(ttlMinutes),
+      signature,
       status: TransactionStatus.NEW,
     });
 
@@ -43,7 +75,7 @@ export class NfcTransactionBuilder {
       transaction.tenantId,
       enrollment.userId,
       tokenData.cardId,
-      tokenData.amount,
+      tokenData.amount * 0.01,
     ];
 
     return { transaction, processPaymentArgs };

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+
+import { TokenData } from './nfc-authorization.service';
+import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
+import type { TerminalEntity } from '../../terminals/domain/ports/terminal-repository.port';
+import type { NfcEnrollmentEntity } from '../domain/ports/nfc-enrollment-repository.port';
+
+export interface NfcTransactionBuildInput {
+  tokenData: TokenData;
+  enrollment: NfcEnrollmentEntity;
+  terminal: TerminalEntity | null;
+}
+
+export type ProcessPaymentArgs = [
+  transactionId: string,
+  tenantId: string,
+  customerId: string,
+  cardId: string,
+  amount: number,
+];
+
+export interface NfcTransactionBuildResult {
+  transaction: Transaction;
+  processPaymentArgs: ProcessPaymentArgs;
+}
+
+@Injectable()
+export class NfcTransactionBuilder {
+  build(input: NfcTransactionBuildInput): NfcTransactionBuildResult {
+    const { tokenData, enrollment, terminal } = input;
+
+    const transaction = new Transaction({
+      tenantId: terminal?.tenantId ?? '',
+      customerId: enrollment.userId,
+      cardId: tokenData.cardId,
+      amount: tokenData.amount,
+      intentId: tokenData.sessionId,
+      status: TransactionStatus.NEW,
+    });
+
+    const processPaymentArgs: ProcessPaymentArgs = [
+      transaction.id,
+      transaction.tenantId,
+      enrollment.userId,
+      tokenData.cardId,
+      tokenData.amount,
+    ];
+
+    return { transaction, processPaymentArgs };
+  }
+}

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { createHash } from 'crypto';
 
 import { TokenData } from './nfc-authorization.service';
 import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
@@ -27,6 +26,7 @@ export interface NfcTransactionBuildResult {
 
 @Injectable()
 export class NfcTransactionBuilder {
+  private static readonly DOMAIN_AMOUNT_FACTOR = 0.01;
   private static lastTransactionNo = 0;
   private static readonly TRANSACTION_TTL_MINUTES = 15;
 
@@ -51,9 +51,7 @@ export class NfcTransactionBuilder {
     }
 
     const ttlMinutes = NfcTransactionBuilder.TRANSACTION_TTL_MINUTES;
-    const signature = createHash('sha256')
-      .update(`${tokenData.sessionId}:${tokenData.txRef}:${tokenData.amount}`)
-      .digest('hex');
+    const signature = `${tokenData.sessionId}:${tokenData.nonce}`;
 
     const transaction = new Transaction({
       no: this.nextTransactionNo(),
@@ -75,7 +73,8 @@ export class NfcTransactionBuilder {
       transaction.tenantId,
       enrollment.userId,
       tokenData.cardId,
-      tokenData.amount * 0.01,
+      // Convert request amount (cents) to domain amount (dollars) expected by processPayment.
+      tokenData.amount * NfcTransactionBuilder.DOMAIN_AMOUNT_FACTOR,
     ];
 
     return { transaction, processPaymentArgs };

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-authorization.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-authorization.controller.ts
@@ -33,7 +33,6 @@ import { OAuthScopeGuard, RequiredScopes } from 'src/modules/oauth/infrastructur
 import { NfcAuthorizationService } from '../../application/nfc-authorization.service';
 import { AuthorizePaymentRequestDto } from '../../dto/authorize-payment-request.dto';
 import { AuthorizePaymentResponseDto } from '../../dto/authorize-payment-response.dto';
-import { SocketGateway } from 'src/sockets/sockets.gateway';
 
 @Controller('nfc-payments')
 @ApiTags('NFC Payments')
@@ -41,7 +40,6 @@ import { SocketGateway } from 'src/sockets/sockets.gateway';
 export class NfcAuthorizationController {
   constructor(
     private readonly authorizationService: NfcAuthorizationService,
-    private readonly socketGateway: SocketGateway,
   ) {}
 
   @Post('authorize')
@@ -69,17 +67,6 @@ export class NfcAuthorizationController {
   ): Promise<Response> {
     const clientId = (req as any).user?.clientId;
     const result = await this.authorizationService.authorizePayment(dto, clientId);
-
-    // Notify the phone app via WebSocket (room = NFC sessionId)
-    if (result.approved && result.sessionId) {
-      this.socketGateway.sendToRoom(result.sessionId, 'payment.result', {
-        status: 'success',
-        transactionId: result.txId,
-        amount: result.amount,
-        currency: result.currency,
-        timestamp: new Date().toISOString(),
-      });
-    }
 
     return res.status(HttpStatus.OK).json({
       ok: result.approved,

--- a/src/modules/nfc-payments/nfc-payments.module.ts
+++ b/src/modules/nfc-payments/nfc-payments.module.ts
@@ -32,6 +32,7 @@ import { NfcPrepareController } from './infrastructure/controllers/nfc-prepare.c
 // Authorization (Slice 8)
 import { NfcAuthorizationService } from './application/nfc-authorization.service';
 import { NfcAuthorizationController } from './infrastructure/controllers/nfc-authorization.controller';
+import { NfcTransactionBuilder } from './application/nfc-transaction.builder';
 
 // Reused adapters from other modules
 import { EcdhCryptoAdapter } from '../devices/infrastructure/adapters/ecdh-crypto.adapter';
@@ -42,6 +43,7 @@ import { INJECTION_TOKENS } from 'src/common/constants/injection-tokens';
 import { VaultHttpAdapter } from '../vault/infrastructure/adapters/vault-http.adapter';
 import { TerminalsModule } from '../terminals/terminals.module';
 import { SocketsModule } from 'src/sockets/sockets.module';
+import { TransactionsModule } from '../transactions/transactions.module';
 
 @Module({
   imports: [
@@ -53,6 +55,7 @@ import { SocketsModule } from 'src/sockets/sockets.module';
     CachingModule,
     TerminalsModule,
     SocketsModule,
+    TransactionsModule,
   ],
   controllers: [NfcEnrollmentController, NfcPrepareController, NfcAuthorizationController],
   providers: [
@@ -84,6 +87,7 @@ import { SocketsModule } from 'src/sockets/sockets.module';
     NfcPrepareService,
     // Slice 8: Authorization
     NfcAuthorizationService,
+    NfcTransactionBuilder,
   ],
   exports: [
     NFC_PAYMENT_INJECTION_TOKENS.TLV_CODEC_PORT,

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -84,7 +84,7 @@ import { PaymentSocketNotifier } from './application/services/payment-socket-not
         // Socket notifier
         PaymentSocketNotifier,
     ],
-    exports: [TransactionService, TransactionQueryService, DashboardService],
+    exports: [TransactionService, TransactionQueryService, DashboardService, TransactionsRepository, TransactionPaymentProcessor],
 })
 export class TransactionsModule { }
 


### PR DESCRIPTION
## Summary

- After ECDSA signature verification, NFC `/nfc-payments/authorize` now persists a `Transaction` and dispatches to SGT via the existing `TransactionPaymentProcessor` — the same path QR uses — so NFC payments actually settle with the Clásica issuer instead of stopping at a local crypto-only approval.
- New deep module `NfcTransactionBuilder` (pure, 4 unit tests) maps `tokenData + enrollment + terminal` → `Transaction` + `processPayment` args. `tenantId` is derived from the OAuth `clientId` via the existing terminal lookup; `intentId` is set to `tokenData.sessionId` so `PaymentSocketNotifier` emits `payment.result` to the room the phone already joined.
- Failure paths covered: SGT rejection (TR001/TR002/TR003) propagates as `approved=false` with `transferCode`/`isoResponseCode`/`status=FAILED`; SGT exceptions (unreachable) are caught and returned as a clean `SGT_UNREACHABLE` failure; invalid signatures short-circuit before any `Transaction` is persisted. Nonce/counter remain consumed in all failure modes.
- Removed the duplicate WebSocket emission from `NfcAuthorizationController` now that `PaymentSocketNotifier` handles it via the `transaction.processed` event.

Closes #15
Closes #16
PRD: #14

## Test plan

- [x] `yarn test --testPathPatterns="nfc-(authorization.service|transaction.builder)"` — 24/24 green
- [x] `yarn build` — green
- [ ] Manual E2E against SGT in dev: NFC tap → terminal sees real `transferCode`, phone receives `payment.result` via WebSocket, `Transaction` row in Mongo with status `SUCCESS`/`FAILED`
- [ ] Manual E2E failure: SGT rejection path shows correct `isoResponseCode` on terminal
- [ ] Manual E2E unreachable: stop SGT, NFC tap → terminal shows `SGT_UNREACHABLE`, no orphan WebSocket success event
