### PR TITLE
fix(nfc): surface NFC→SGT dispatch in container logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Git worktrees
+.worktrees/

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,21 @@ async function bootstrap() {
   // App
   // Console verbosity is controlled by LOG_LEVEL env var (error | warn | info | http | verbose | debug | silly).
   // Default 'info' matches Winston defaults and keeps `logger.log()` breadcrumbs visible in containerized deployments.
-  const consoleLogLevel = process.env.LOG_LEVEL || 'info';
+  const supportedLogLevels = [
+    'error',
+    'warn',
+    'info',
+    'http',
+    'verbose',
+    'debug',
+    'silly',
+  ] as const;
+  const normalizedLogLevel = process.env.LOG_LEVEL?.trim().toLowerCase();
+  const consoleLogLevel = supportedLogLevels.includes(
+    normalizedLogLevel as (typeof supportedLogLevels)[number],
+  )
+    ? normalizedLogLevel
+    : 'info';
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: WinstonModule.createLogger({
       transports: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,10 +34,14 @@ async function bootstrap() {
   const logger = new Logger('bootstrap');
 
   // App
+  // Console verbosity is controlled by LOG_LEVEL env var (error | warn | info | http | verbose | debug | silly).
+  // Default 'info' matches Winston defaults and keeps `logger.log()` breadcrumbs visible in containerized deployments.
+  const consoleLogLevel = process.env.LOG_LEVEL || 'info';
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: WinstonModule.createLogger({
       transports: [
         new winston.transports.Console({
+          level: consoleLogLevel,
           format: winston.format.combine(
             winston.format.colorize({ all: true }),
             winston.format.timestamp({

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -241,7 +241,7 @@ export class NfcAuthorizationService {
       }
       try {
         this.logger.log(
-          `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${processPaymentArgs[4]}, sessionId=${tokenData.sessionId}`,
+          `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${processPaymentArgs[4]}`,
         );
         const paymentResult = await this.paymentProcessor.processPayment(
           processingTransaction.id,

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -240,12 +240,18 @@ export class NfcAuthorizationService {
         throw new Error(`Transaction missing cardId: ${persisted.id}`);
       }
       try {
+        this.logger.log(
+          `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${processPaymentArgs[4]}, sessionId=${tokenData.sessionId}`,
+        );
         const paymentResult = await this.paymentProcessor.processPayment(
           processingTransaction.id,
           processingTransaction.tenantId,
           processingTransaction.customerId,
           processingTransaction.cardId,
           processPaymentArgs[4],
+        );
+        this.logger.log(
+          `SGT dispatch returned for txId=${processingTransaction.id}: approved=${paymentResult.success}, transferCode=${paymentResult.transferCode}, status=${paymentResult.status}`,
         );
 
         authorizationResult = {
@@ -389,7 +395,7 @@ export class NfcAuthorizationService {
         throw new Error('ENROLLMENT_COUNTER_NOT_MONOTONIC');
       }
 
-      this.logger.debug(
+      this.logger.log(
         `Enrollment counter for card ${cardId} updated to ${newCounter}`,
       );
     } catch (err) {

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
@@ -108,6 +108,22 @@ describe('NfcTransactionBuilder', () => {
 
       // Sensitive fields must never appear in info-level logs
       expect(messages).not.toContain(tokenData.nonce);
+      expect(messages).not.toContain(tokenData.sessionId);
+
+      const tokenDataWithoutTxRef: TokenData = {
+        ...tokenData,
+        txRef: undefined,
+      };
+
+      builder.build({ tokenData: tokenDataWithoutTxRef, enrollment, terminal });
+
+      const messagesWithoutTxRef = spy.mock.calls
+        .map((call) => (typeof call[0] === 'string' ? call[0] : JSON.stringify(call[0])))
+        .join('\n');
+
+      expect(messagesWithoutTxRef).toContain('NFC transaction built');
+      expect(messagesWithoutTxRef).not.toContain(tokenDataWithoutTxRef.nonce);
+      expect(messagesWithoutTxRef).not.toContain(tokenDataWithoutTxRef.sessionId);
     } finally {
       spy.mockRestore();
     }

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts
@@ -5,6 +5,8 @@
  * No I/O, no DI — just data shaping.
  */
 
+import { Logger } from '@nestjs/common';
+
 import { NfcTransactionBuilder } from './nfc-transaction.builder';
 import { TokenData } from './nfc-authorization.service';
 import { TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
@@ -87,5 +89,27 @@ describe('NfcTransactionBuilder', () => {
     expect(() =>
       builder.build({ tokenData, enrollment, terminal: null as unknown as TerminalEntity }),
     ).toThrow('Cannot build NFC transaction without a tenantId');
+  });
+
+  it('emits an info-level log on build() with a sanitized token snapshot (no nonce, no sessionId body)', () => {
+    const spy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    try {
+      const { transaction } = builder.build({ tokenData, enrollment, terminal });
+
+      const messages = spy.mock.calls
+        .map((call) => (typeof call[0] === 'string' ? call[0] : JSON.stringify(call[0])))
+        .join('\n');
+
+      expect(messages).toContain('NFC transaction built');
+      expect(messages).toContain(tokenData.cardId);
+      expect(messages).toContain(terminal.tenantId);
+      expect(messages).toContain(String(tokenData.amount));
+      expect(messages).toContain(transaction.id);
+
+      // Sensitive fields must never appear in info-level logs
+      expect(messages).not.toContain(tokenData.nonce);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.ts
@@ -79,7 +79,7 @@ export class NfcTransactionBuilder {
     ];
 
     this.logger.log(
-      `NFC transaction built: txId=${transaction.id}, cardId=${tokenData.cardId}, tenantId=${terminal.tenantId}, amount=${tokenData.amount} ${tokenData.currency}, domainAmount=${processPaymentArgs[4]}, customerId=${enrollment.userId}, txRef=${transaction.ref}`,
+      `NFC transaction built: txId=${transaction.id}, cardId=${tokenData.cardId}, tenantId=${terminal.tenantId}, amount=${tokenData.amount} ${tokenData.currency}, domainAmount=${processPaymentArgs[4]}, customerId=${enrollment.userId}`,
     );
 
     return { transaction, processPaymentArgs };

--- a/src/modules/nfc-payments/application/nfc-transaction.builder.ts
+++ b/src/modules/nfc-payments/application/nfc-transaction.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { TokenData } from './nfc-authorization.service';
 import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
@@ -26,6 +26,7 @@ export interface NfcTransactionBuildResult {
 
 @Injectable()
 export class NfcTransactionBuilder {
+  private readonly logger = new Logger(NfcTransactionBuilder.name);
   private static readonly DOMAIN_AMOUNT_FACTOR = 0.01;
   private static lastTransactionNo = 0;
   private static readonly TRANSACTION_TTL_MINUTES = 15;
@@ -76,6 +77,10 @@ export class NfcTransactionBuilder {
       // Convert request amount (cents) to domain amount (dollars) expected by processPayment.
       tokenData.amount * NfcTransactionBuilder.DOMAIN_AMOUNT_FACTOR,
     ];
+
+    this.logger.log(
+      `NFC transaction built: txId=${transaction.id}, cardId=${tokenData.cardId}, tenantId=${terminal.tenantId}, amount=${tokenData.amount} ${tokenData.currency}, domainAmount=${processPaymentArgs[4]}, customerId=${enrollment.userId}, txRef=${transaction.ref}`,
+    );
 
     return { transaction, processPaymentArgs };
   }


### PR DESCRIPTION
## Summary

- Closes #20. NFC→SGT dispatch was silent in production because the NFC-side steps logged at `debug` and Nest had no env-driven console level.
- `NfcTransactionBuilder` now emits an info-level line with txId/cardId/tenantId/amount on every build (sensitive fields excluded).
- `NfcAuthorizationService` logs before and after the `processPayment()` call (txId, transferCode, status) and promotes the enrollment counter update from `debug` to `log`.
- `main.ts` honours `LOG_LEVEL` on the Winston console transport, default `info`.

## Test plan

- [ ] `yarn test src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts` passes (new log assertion + 4 existing).
- [ ] `yarn test src/modules/nfc-payments/application/nfc-authorization.service.spec.ts` still passes.
- [ ] Deploy dev container and tap an NFC card; verify the log sequence `NFC transaction built` → `Dispatching NFC payment to SGT` → `Procesando pago para transacción=…` → `Llamando SGT /transfer` → `SGT /transfer respondió` → `SGT dispatch returned` appears in order on stdout.
- [ ] Set `LOG_LEVEL=debug` and verify previously-suppressed HKDF/ECDSA debug lines now appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)