### PR TITLE
fix(nfc): persist userId on NfcEnrollment schema

### DIFF
--- a/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
+++ b/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
@@ -16,6 +16,9 @@ export class NfcEnrollment extends AbstractSchema {
   cardId: string;
 
   @Prop({ required: true })
+  userId: string; // Cardholder user id — persisted so NFC→SGT dispatch can look up the user
+
+  @Prop({ required: true })
   devicePublicKey: string; // Base64 of 65-byte uncompressed P-256
 
   @Prop({ required: true })


### PR DESCRIPTION
## Summary

- Adds the missing `@Prop({ required: true }) userId: string` to `NfcEnrollment` so the Mongoose write path actually persists the field the repo mapper, the index, and the application service all already assume exists.
- Without this, Mongoose strict-mode silently drops `userId` at write time, every enrollment doc is stored without it, `NfcEnrollmentEntity.userId` comes back `undefined`, and `TransactionPaymentProcessor.processPayment()` short-circuits at the user lookup (`"Usuario no encontrado"`) before any SGT call — which is why NFC→SGT appeared silent end-to-end even after #21 surfaced the breadcrumbs.

## Post-merge steps (dev)

Legacy enrollments written under the broken schema still lack `userId` and will keep failing. In dev, purge them and re-enrol:

```js
// mongosh
db.nfc_enrollments.deleteMany({ userId: { \$exists: false } });
```

Then re-enrol each card from the mobile app.

## Test plan

- [ ] `yarn test src/modules/nfc-payments` — existing specs still pass.
- [ ] Drop orphaned enrollments, re-enrol the test card, tap NFC, confirm the log sequence continues past `Usuario encontrado: <id>` through `Llamando SGT /transfer` → `SGT /transfer respondió` with a real `transferCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)