### PR TITLE
fix(nfc): persist enrollment userId by reading JWT actorId + drop bad schema prop

### DIFF
--- a/src/common/types/authenticated-request.type.ts
+++ b/src/common/types/authenticated-request.type.ts
@@ -1,0 +1,5 @@
+import type { Request } from 'express';
+
+import type { Actor } from '../interfaces';
+
+export type AuthenticatedRequest = Request & { user: Actor };

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,3 +1,4 @@
+export * from './authenticated-request.type';
 export * from './api-response.type';
 export * from './common.types';
 export * from './navigation-item.type';

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
@@ -17,7 +17,7 @@ import {
   HttpStatus,
   Res,
 } from '@nestjs/common';
-import type { Response } from 'express';
+import type { Request as ExpressRequest, Response } from 'express';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -32,10 +32,13 @@ import {
   ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 
+import type { Actor } from 'src/common/interfaces';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
 import { NfcEnrollmentService } from '../../application/nfc-enrollment.service';
 import { NfcEnrollmentRequestDto } from '../../dto/nfc-enrollment-request.dto';
 import { NfcEnrollmentResponseDto } from '../../dto/nfc-enrollment-response.dto';
+
+type AuthenticatedRequest = ExpressRequest & { user: Actor };
 
 @Controller('cards')
 @ApiTags('NFC Enrollment')
@@ -69,7 +72,7 @@ export class NfcEnrollmentController {
   async enrollCard(
     @Param('cardId') cardId: string,
     @Body() dto: NfcEnrollmentRequestDto,
-    @Request() req: any,
+    @Request() req: AuthenticatedRequest,
     @Res() res: Response,
   ): Promise<Response> {
     const result = await this.enrollmentService.enrollCard(
@@ -103,7 +106,7 @@ export class NfcEnrollmentController {
   @ApiInternalServerErrorResponse({ description: 'Error during revocation process' })
   async revokeEnrollment(
     @Param('cardId') cardId: string,
-    @Request() req: any,
+    @Request() req: AuthenticatedRequest,
     @Res() res: Response,
   ): Promise<Response> {
     await this.enrollmentService.revokeEnrollment(cardId, req.user.actorId);

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
@@ -17,7 +17,7 @@ import {
   HttpStatus,
   Res,
 } from '@nestjs/common';
-import type { Request as ExpressRequest, Response } from 'express';
+import type { Response } from 'express';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -32,13 +32,11 @@ import {
   ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 
-import type { Actor } from 'src/common/interfaces';
+import type { AuthenticatedRequest } from 'src/common/types';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
 import { NfcEnrollmentService } from '../../application/nfc-enrollment.service';
 import { NfcEnrollmentRequestDto } from '../../dto/nfc-enrollment-request.dto';
 import { NfcEnrollmentResponseDto } from '../../dto/nfc-enrollment-response.dto';
-
-type AuthenticatedRequest = ExpressRequest & { user: Actor };
 
 @Controller('cards')
 @ApiTags('NFC Enrollment')

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-enrollment.controller.ts
@@ -73,7 +73,7 @@ export class NfcEnrollmentController {
     @Res() res: Response,
   ): Promise<Response> {
     const result = await this.enrollmentService.enrollCard(
-      req.user.userId,
+      req.user.actorId,
       cardId,
       dto.devicePublicKey,
     );
@@ -106,7 +106,7 @@ export class NfcEnrollmentController {
     @Request() req: any,
     @Res() res: Response,
   ): Promise<Response> {
-    await this.enrollmentService.revokeEnrollment(cardId, req.user.userId);
+    await this.enrollmentService.revokeEnrollment(cardId, req.user.actorId);
     return res.status(HttpStatus.OK).json({
       ok: true,
       statusCode: HttpStatus.OK,

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
@@ -15,7 +15,7 @@ import {
   HttpStatus,
   Res,
 } from '@nestjs/common';
-import type { Response } from 'express';
+import type { Request as ExpressRequest, Response } from 'express';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -28,10 +28,13 @@ import {
   ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 
+import type { Actor } from 'src/common/interfaces';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
 import { NfcPrepareService } from '../../application/nfc-prepare.service';
 import { NfcPrepareRequestDto } from '../../dto/nfc-prepare-request.dto';
 import { NfcPrepareResponseDto } from '../../dto/nfc-prepare-response.dto';
+
+type AuthenticatedRequest = ExpressRequest & { user: Actor };
 
 @Controller('payment-tokens')
 @ApiTags('NFC Payments')
@@ -58,7 +61,7 @@ export class NfcPrepareController {
   @ApiInternalServerErrorResponse({ description: 'Error preparing payment session' })
   async prepare(
     @Body() dto: NfcPrepareRequestDto,
-    @Request() req: any,
+    @Request() req: AuthenticatedRequest,
     @Res() res: Response,
   ): Promise<Response> {
     const result = await this.prepareService.preparePaymentSession(

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
@@ -15,7 +15,7 @@ import {
   HttpStatus,
   Res,
 } from '@nestjs/common';
-import type { Request as ExpressRequest, Response } from 'express';
+import type { Response } from 'express';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -28,13 +28,11 @@ import {
   ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 
-import type { Actor } from 'src/common/interfaces';
+import type { AuthenticatedRequest } from 'src/common/types';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
 import { NfcPrepareService } from '../../application/nfc-prepare.service';
 import { NfcPrepareRequestDto } from '../../dto/nfc-prepare-request.dto';
 import { NfcPrepareResponseDto } from '../../dto/nfc-prepare-response.dto';
-
-type AuthenticatedRequest = ExpressRequest & { user: Actor };
 
 @Controller('payment-tokens')
 @ApiTags('NFC Payments')

--- a/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
+++ b/src/modules/nfc-payments/infrastructure/controllers/nfc-prepare.controller.ts
@@ -62,7 +62,7 @@ export class NfcPrepareController {
     @Res() res: Response,
   ): Promise<Response> {
     const result = await this.prepareService.preparePaymentSession(
-      req.user.userId,
+      req.user.actorId,
       dto.cardId,
     );
     return res.status(HttpStatus.OK).json({

--- a/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
+++ b/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
@@ -12,6 +12,9 @@ export type NfcEnrollmentDocument = HydratedDocument<NfcEnrollment>;
 
 @Schema({ collection: 'nfc_enrollments', timestamps: true })
 export class NfcEnrollment extends AbstractSchema {
+  @Prop({ type: String, required: true, ref: 'User', index: true })
+  declare userId: string;
+
   @Prop({ required: true, unique: true, index: true })
   cardId: string;
 

--- a/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
+++ b/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
@@ -12,6 +12,7 @@ export type NfcEnrollmentDocument = HydratedDocument<NfcEnrollment>;
 
 @Schema({ collection: 'nfc_enrollments', timestamps: true })
 export class NfcEnrollment extends AbstractSchema {
+  // Re-declare userId here so Mongo keeps it required without triggering TS2612 on the inherited property.
   @Prop({ type: String, required: true, ref: 'User', index: true })
   declare userId: string;
 

--- a/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
+++ b/src/modules/nfc-payments/infrastructure/schemas/nfc-enrollment.schema.ts
@@ -16,9 +16,6 @@ export class NfcEnrollment extends AbstractSchema {
   cardId: string;
 
   @Prop({ required: true })
-  userId: string; // Cardholder user id — persisted so NFC→SGT dispatch can look up the user
-
-  @Prop({ required: true })
   devicePublicKey: string; // Base64 of 65-byte uncompressed P-256
 
   @Prop({ required: true })


### PR DESCRIPTION
## Summary

Follow-up to #22, which shipped a wrong fix and broke the builder container.

- **Revert** the redundant `@Prop({ required: true }) userId` on `NfcEnrollment`. `AbstractSchema` already declares it (`@Prop({ type: String, required: false, ref: 'User' }) userId?: string`), so the duplicate triggered TS2612 and failed `yarn build` under Docker.
- **Real root cause**: the NFC enrollment, prepare and revoke controllers read `req.user.userId` from the request. The JWT strategy's `validate()` returns an `Actor` object with `actorId`, `actorType`, `tenantId`, `sub`, etc. — **no `userId`**. So `req.user.userId` was always `undefined`, every enrollment was persisted with no user reference, and `NfcTransactionBuilder` later produced `Transaction.customerId = undefined`, short-circuiting the SGT dispatch at the user lookup. Three callsites switched to `req.user.actorId`.

## Verification

- `yarn build` — clean (TS2612 gone).
- `yarn test src/modules/nfc-payments/application/nfc-authorization.service.spec.ts src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts` — 27/27 pass (unchanged).
- Pre-existing failures in `nfc-enrollment.service.spec.ts` / `nfc-prepare.service.spec.ts` also fail on `main`, unrelated.

## Post-merge (dev)

Orphaned enrollments (without `userId`) are still in Mongo from previous builds. Purge + re-enrol the test card:

\`\`\`js
// mongosh
db.nfc_enrollments.deleteMany({ userId: { \$exists: false } });
\`\`\`

Then the NFC→SGT E2E should continue past `Usuario encontrado: <id>` into `Llamando SGT /transfer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)