### PR TITLE
feat(nfc): emit payment.processing and carry amount/currency to phone

### DIFF
--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -351,6 +351,25 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
 
     it('should persist Transaction and dispatch to SGT, returning transferCode/status on success', async () => {
       const { signedPayload, tokenData } = buildValidSignedPayload();
+      const callSequence: string[] = [];
+      mockSocketGateway.sendToRoom.mockImplementation(() => {
+        callSequence.push('payment.processing');
+      });
+      mockPaymentProcessor.processPayment.mockImplementationOnce(async (transactionId: string) => {
+        callSequence.push('processPayment');
+        return {
+          success: true,
+          status: TransactionStatus.SUCCESS,
+          transferCode: 'TR000',
+          isoResponseCode: '00',
+          updatedTransaction: new Transaction({
+            id: transactionId,
+            status: TransactionStatus.SUCCESS,
+            sgtTransferCode: 'TR000',
+            sgtIsoResponseCode: '00',
+          }),
+        };
+      });
 
       const result = await service.authorizePayment(
         {
@@ -390,9 +409,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
           currency: tokenData.currency,
         }),
       );
-      expect(mockSocketGateway.sendToRoom.mock.invocationCallOrder[0]).toBeLessThan(
-        mockPaymentProcessor.processPayment.mock.invocationCallOrder[0],
-      );
+      expect(callSequence).toEqual(['payment.processing', 'processPayment']);
 
       expect(result.approved).toBe(true);
       expect(result.txId).toBe(persisted.id);

--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -125,6 +125,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
   let mockConfigService: Partial<jest.Mocked<ConfigService>>;
   let mockTransactionsRepository: { create: jest.Mock; updateStatus: jest.Mock };
   let mockPaymentProcessor: { processPayment: jest.Mock };
+  let mockSocketGateway: { sendToRoom: jest.Mock };
 
   // Use the real TLV codec for building test payloads
   const realCodec = new TlvCodecAdapter();
@@ -269,6 +270,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         }),
       ),
     };
+    mockSocketGateway = { sendToRoom: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -320,7 +322,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         NfcTransactionBuilder,
         {
           provide: SocketGateway,
-          useValue: { sendToRoom: jest.fn() },
+          useValue: mockSocketGateway,
         },
       ],
     }).compile();
@@ -377,6 +379,19 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
       expect(mockTransactionsRepository.updateStatus).toHaveBeenCalledWith(
         persisted.id,
         TransactionStatus.PROCESSING,
+      );
+      expect(mockSocketGateway.sendToRoom).toHaveBeenCalledWith(
+        tokenData.sessionId,
+        'payment.processing',
+        expect.objectContaining({
+          transactionId: persisted.id,
+          intentId: tokenData.sessionId,
+          amount: tokenData.amount * 0.01,
+          currency: tokenData.currency,
+        }),
+      );
+      expect(mockSocketGateway.sendToRoom.mock.invocationCallOrder[0]).toBeLessThan(
+        mockPaymentProcessor.processPayment.mock.invocationCallOrder[0],
       );
 
       expect(result.approved).toBe(true);

--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -33,6 +33,7 @@ import { TransactionsRepository } from '../../transactions/infrastructure/adapte
 import { TransactionPaymentProcessor } from '../../transactions/application/services/transaction-payment.processor';
 import { Transaction, TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
 import { NfcTransactionBuilder } from './nfc-transaction.builder';
+import { SocketGateway } from 'src/sockets/sockets.gateway';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -317,6 +318,10 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
           useValue: mockPaymentProcessor,
         },
         NfcTransactionBuilder,
+        {
+          provide: SocketGateway,
+          useValue: { sendToRoom: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -367,6 +372,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         expect.any(String),
         tokenData.cardId,
         tokenData.amount * 0.01,
+        tokenData.currency,
       );
       expect(mockTransactionsRepository.updateStatus).toHaveBeenCalledWith(
         persisted.id,

--- a/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.spec.ts
@@ -351,6 +351,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
 
     it('should persist Transaction and dispatch to SGT, returning transferCode/status on success', async () => {
       const { signedPayload, tokenData } = buildValidSignedPayload();
+      const expectedDomainAmount = tokenData.amount / 100;
       const callSequence: string[] = [];
       mockSocketGateway.sendToRoom.mockImplementation(() => {
         callSequence.push('payment.processing');
@@ -392,7 +393,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         'tenant-001',
         expect.any(String),
         tokenData.cardId,
-        tokenData.amount * 0.01,
+        expectedDomainAmount,
         tokenData.currency,
       );
       expect(mockTransactionsRepository.updateStatus).toHaveBeenCalledWith(
@@ -405,7 +406,7 @@ describe('NfcAuthorizationService (Unit Tests)', () => {
         expect.objectContaining({
           transactionId: persisted.id,
           intentId: tokenData.sessionId,
-          amount: tokenData.amount * 0.01,
+          amount: expectedDomainAmount,
           currency: tokenData.currency,
         }),
       );

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -224,6 +224,7 @@ export class NfcAuthorizationService {
       enrollment,
       terminal,
     });
+    const [, , , , domainAmount] = processPaymentArgs;
 
     let persisted: Awaited<ReturnType<TransactionsRepository['create']>>;
     let authorizationResult: AuthorizationResult | null = null;
@@ -243,7 +244,7 @@ export class NfcAuthorizationService {
       }
       try {
         this.logger.log(
-          `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${processPaymentArgs[4]}`,
+          `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${domainAmount}`,
         );
 
         // Signal "tap complete, waiting on issuer" to the phone before the SGT call.
@@ -251,7 +252,7 @@ export class NfcAuthorizationService {
         this.socketGateway.sendToRoom(tokenData.sessionId, 'payment.processing', {
           transactionId: processingTransaction.id,
           intentId: tokenData.sessionId,
-          amount: processPaymentArgs[4],
+          amount: domainAmount,
           currency: tokenData.currency,
           timestamp: new Date().toISOString(),
         });
@@ -261,7 +262,7 @@ export class NfcAuthorizationService {
           processingTransaction.tenantId,
           processingTransaction.customerId,
           processingTransaction.cardId,
-          processPaymentArgs[4],
+          domainAmount,
           tokenData.currency,
         );
         this.logger.log(

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -251,7 +251,7 @@ export class NfcAuthorizationService {
         this.socketGateway.sendToRoom(tokenData.sessionId, 'payment.processing', {
           transactionId: processingTransaction.id,
           intentId: tokenData.sessionId,
-          amount: tokenData.amount,
+          amount: processPaymentArgs[4],
           currency: tokenData.currency,
           timestamp: new Date().toISOString(),
         });

--- a/src/modules/nfc-payments/application/nfc-authorization.service.ts
+++ b/src/modules/nfc-payments/application/nfc-authorization.service.ts
@@ -28,6 +28,7 @@ import { TransactionsRepository } from '../../transactions/infrastructure/adapte
 import { TransactionPaymentProcessor } from '../../transactions/application/services/transaction-payment.processor';
 import { TransactionStatus } from '../../transactions/domain/entities/transaction.entity';
 import { NfcTransactionBuilder } from './nfc-transaction.builder';
+import { SocketGateway } from 'src/sockets/sockets.gateway';
 
 export interface TokenData {
   cardId: string;
@@ -97,6 +98,7 @@ export class NfcAuthorizationService {
     private readonly transactionsRepository: TransactionsRepository,
     private readonly paymentProcessor: TransactionPaymentProcessor,
     private readonly transactionBuilder: NfcTransactionBuilder,
+    private readonly socketGateway: SocketGateway,
   ) {}
 
   async authorizePayment(
@@ -243,12 +245,24 @@ export class NfcAuthorizationService {
         this.logger.log(
           `Dispatching NFC payment to SGT: txId=${processingTransaction.id}, tenantId=${processingTransaction.tenantId}, cardId=${processingTransaction.cardId}, domainAmount=${processPaymentArgs[4]}`,
         );
+
+        // Signal "tap complete, waiting on issuer" to the phone before the SGT call.
+        // The room is the NFC sessionId that the phone joined after prepare.
+        this.socketGateway.sendToRoom(tokenData.sessionId, 'payment.processing', {
+          transactionId: processingTransaction.id,
+          intentId: tokenData.sessionId,
+          amount: tokenData.amount,
+          currency: tokenData.currency,
+          timestamp: new Date().toISOString(),
+        });
+
         const paymentResult = await this.paymentProcessor.processPayment(
           processingTransaction.id,
           processingTransaction.tenantId,
           processingTransaction.customerId,
           processingTransaction.cardId,
           processPaymentArgs[4],
+          tokenData.currency,
         );
         this.logger.log(
           `SGT dispatch returned for txId=${processingTransaction.id}: approved=${paymentResult.success}, transferCode=${paymentResult.transferCode}, status=${paymentResult.status}`,

--- a/src/modules/transactions/application/services/payment-socket-notifier.ts
+++ b/src/modules/transactions/application/services/payment-socket-notifier.ts
@@ -20,7 +20,13 @@ export class PaymentSocketNotifier {
 
   @OnEvent('transaction.processed')
   async handleTransactionProcessed(event: TransactionProcessedEvent): Promise<void> {
-    await this.emitPaymentResult(event.transactionId, event.status, event.error ?? null);
+    await this.emitPaymentResult(
+      event.transactionId,
+      event.status,
+      event.error ?? null,
+      event.amount,
+      event.currency,
+    );
   }
 
   @OnEvent('transaction.expired')
@@ -37,6 +43,8 @@ export class PaymentSocketNotifier {
     transactionId: string,
     status: string,
     error: string | null = null,
+    amount?: number,
+    currency?: string,
   ): Promise<void> {
     const transaction = await this.transactionsRepository.findById(transactionId);
     if (!transaction) {
@@ -49,6 +57,8 @@ export class PaymentSocketNotifier {
       intentId: transaction.intentId,
       status,
       error,
+      amount: amount ?? transaction.amount,
+      currency,
       timestamp: new Date().toISOString(),
     });
   }

--- a/src/modules/transactions/application/services/transaction-payment.processor.spec.ts
+++ b/src/modules/transactions/application/services/transaction-payment.processor.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { INJECTION_TOKENS } from 'src/common/constants/injection-tokens';
+import { AuditService } from 'src/modules/audit/application/audit.service';
+import { CardsRepository } from 'src/modules/cards/infrastructure/adapters/card.repository';
+import { CardVaultAdapter } from 'src/modules/cards/infrastructure/adapters/card-vault.adapter';
+import { TenantsRepository } from 'src/modules/tenants/infrastructure/adapters/tenant.repository';
+import { TenantVaultService } from 'src/modules/tenants/infrastructure/services/tenant-vault.service';
+import { UsersRepository } from 'src/modules/users/infrastructure/adapters';
+import { TransactionStatus } from '../../domain/entities/transaction.entity';
+import { TransactionsRepository } from '../../infrastructure/adapters/transactions.repository';
+import { TransactionPaymentProcessor } from './transaction-payment.processor';
+
+describe('TransactionPaymentProcessor', () => {
+  let processor: TransactionPaymentProcessor;
+  let cardsRepository: { findById: jest.Mock; update: jest.Mock };
+  let transactionsRepository: { updateStatus: jest.Mock };
+  let eventEmitter: { emit: jest.Mock };
+  let auditService: { logError: jest.Mock; logAllow: jest.Mock };
+
+  beforeEach(async () => {
+    cardsRepository = {
+      findById: jest.fn().mockResolvedValue(null),
+      update: jest.fn(),
+    };
+    transactionsRepository = {
+      updateStatus: jest.fn().mockResolvedValue({
+        id: 'txn-1',
+        status: TransactionStatus.FAILED,
+      }),
+    };
+    eventEmitter = { emit: jest.fn() };
+    auditService = {
+      logError: jest.fn(),
+      logAllow: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionPaymentProcessor,
+        { provide: AuditService, useValue: auditService },
+        { provide: CardsRepository, useValue: cardsRepository },
+        { provide: CardVaultAdapter, useValue: { getPinblock: jest.fn() } },
+        { provide: EventEmitter2, useValue: eventEmitter },
+        { provide: INJECTION_TOKENS.CARD_SGT_PORT, useValue: { transfer: jest.fn() } },
+        { provide: TenantsRepository, useValue: { findById: jest.fn() } },
+        { provide: TenantVaultService, useValue: { getPan: jest.fn() } },
+        { provide: TransactionsRepository, useValue: transactionsRepository },
+        { provide: UsersRepository, useValue: { findByIdRaw: jest.fn() } },
+      ],
+    }).compile();
+
+    processor = module.get<TransactionPaymentProcessor>(TransactionPaymentProcessor);
+  });
+
+  it('preserves amount and currency on card-not-found failures', async () => {
+    const result = await processor.processPayment(
+      'txn-1',
+      'tenant-1',
+      'customer-1',
+      'card-404',
+      15,
+      'USD',
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        status: TransactionStatus.FAILED,
+        error: 'Tarjeta no encontrada',
+      }),
+    );
+    expect(transactionsRepository.updateStatus).toHaveBeenCalledWith(
+      'txn-1',
+      TransactionStatus.FAILED,
+      expect.objectContaining({
+        processedAt: expect.any(Date),
+      }),
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'transaction.processed',
+      expect.objectContaining({
+        transactionId: 'txn-1',
+        tenantId: 'tenant-1',
+        status: 'failed',
+        error: 'Tarjeta no encontrada',
+        amount: 15,
+        currency: 'USD',
+      }),
+    );
+    expect(auditService.logError).toHaveBeenCalled();
+  });
+});

--- a/src/modules/transactions/application/services/transaction-payment.processor.ts
+++ b/src/modules/transactions/application/services/transaction-payment.processor.ts
@@ -80,15 +80,36 @@ export class TransactionPaymentProcessor {
       const card = await this.cardsRepository.findById(cardId);
       this.logger.log(`Tarjeta encontrada: ${cardId}`);
       if (!card) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Tarjeta no encontrada');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Tarjeta no encontrada',
+          amount,
+          currency,
+        );
       }
 
       if (card.status !== CardStatusEnum.ACTIVE) {
-        return this.failAndReturn(transactionId, tenantId, customerId, `Tarjeta no activa: ${card.status}`);
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          `Tarjeta no activa: ${card.status}`,
+          amount,
+          currency,
+        );
       }
 
       if (!card.token) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Tarjeta sin token SGT');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Tarjeta sin token SGT',
+          amount,
+          currency,
+        );
       }
 
       // Step 2: Obtener pinblock de la tarjeta desde Vault
@@ -96,27 +117,55 @@ export class TransactionPaymentProcessor {
       this.logger.log(`Pinblock obtenido para tarjeta: ${cardId}`);
       console.log({ pinblockResult });
       if (pinblockResult.isFailure) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Error al recuperar pinblock de Vault');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Error al recuperar pinblock de Vault',
+          amount,
+          currency,
+        );
       }
 
       // Step 3: Obtener datos del usuario (idNumber)
       const user = await this.usersRepository.findByIdRaw(customerId);
       this.logger.log(`Usuario encontrado: ${customerId}`);
       if (!user) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Usuario no encontrado');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Usuario no encontrado',
+          amount,
+          currency,
+        );
       }
 
       // Step 4: Obtener datos del tenant y su PAN (cuenta beneficiaria)
       const tenant = await this.tenantsRepository.findById(tenantId);
       this.logger.log(`Tenant encontrado: ${tenantId}`);
       if (!tenant) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Tenant no encontrado');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Tenant no encontrado',
+          amount,
+          currency,
+        );
       }
 
       const tenantPanResult = await this.tenantVaultService.getPan(tenantId);
       this.logger.log(`PAN del tenant obtenido: ${tenantId}`);
       if (tenantPanResult.isFailure) {
-        return this.failAndReturn(transactionId, tenantId, customerId, 'Error al recuperar PAN del tenant');
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          'Error al recuperar PAN del tenant',
+          amount,
+          currency,
+        );
       }
 
       const beneficiaryAccount = tenantPanResult.getValue();
@@ -165,7 +214,14 @@ export class TransactionPaymentProcessor {
         this.logger.error(
           `SGT /transfer falló para transacción=${transactionId}: ${error.message}`,
         );
-        return this.failAndReturn(transactionId, tenantId, customerId, error.message);
+        return this.failAndReturn(
+          transactionId,
+          tenantId,
+          customerId,
+          error.message,
+          amount,
+          currency,
+        );
       }
 
       const sgtResponse = transferResult.getValue();
@@ -278,7 +334,7 @@ export class TransactionPaymentProcessor {
         error,
       );
 
-      return this.failAndReturn(transactionId, tenantId, customerId, errorMsg);
+      return this.failAndReturn(transactionId, tenantId, customerId, errorMsg, amount, currency);
     }
   }
 

--- a/src/modules/transactions/application/services/transaction-payment.processor.ts
+++ b/src/modules/transactions/application/services/transaction-payment.processor.ts
@@ -69,6 +69,7 @@ export class TransactionPaymentProcessor {
     customerId: string,
     cardId: string,
     amount: number,
+    currency?: string,
   ): Promise<PaymentResult> {
     this.logger.log(
       `Procesando pago para transacción=${transactionId}, card=${cardId}, tenant=${tenantId}`,
@@ -214,7 +215,7 @@ export class TransactionPaymentProcessor {
 
         this.eventEmitter.emit(
           'transaction.processed',
-          new TransactionProcessedEvent(transactionId, tenantId, 'success'),
+          new TransactionProcessedEvent(transactionId, tenantId, 'success', undefined, amount, currency),
         );
 
         return {
@@ -258,7 +259,7 @@ export class TransactionPaymentProcessor {
 
         this.eventEmitter.emit(
           'transaction.processed',
-          new TransactionProcessedEvent(transactionId, tenantId, 'failed', errorMsg),
+          new TransactionProcessedEvent(transactionId, tenantId, 'failed', errorMsg, amount, currency),
         );
 
         return {
@@ -289,6 +290,8 @@ export class TransactionPaymentProcessor {
     tenantId: string,
     customerId: string,
     errorMsg: string,
+    amount?: number,
+    currency?: string,
   ): Promise<PaymentResult> {
     const updatedTransaction = await this.transactionsRepository.updateStatus(
       transactionId,
@@ -311,7 +314,7 @@ export class TransactionPaymentProcessor {
 
     this.eventEmitter.emit(
       'transaction.processed',
-      new TransactionProcessedEvent(transactionId, tenantId, 'failed', errorMsg),
+      new TransactionProcessedEvent(transactionId, tenantId, 'failed', errorMsg, amount, currency),
     );
 
     return {

--- a/src/modules/transactions/domain/events/transaction.events.ts
+++ b/src/modules/transactions/domain/events/transaction.events.ts
@@ -31,6 +31,8 @@ export class TransactionProcessedEvent extends BaseDomainEvent {
     readonly tenantId: string,
     readonly status: 'success' | 'failed',
     readonly error?: string,
+    readonly amount?: number,
+    readonly currency?: string,
   ) {
     super('transaction.processed');
   }


### PR DESCRIPTION
## Summary

Enables the phone to (1) show a distinct \"procesando pago\" screen while the server dispatches to SGT, and (2) display the correct amount + currency on the success screen (prior behaviour was \"0.00 DOP\" because `payment.result` carried neither).

- `NfcAuthorizationService` now emits `payment.processing` to the sessionId room after the Transaction is persisted in PROCESSING status, right before dispatching to `TransactionPaymentProcessor.processPayment()`. Payload includes amount + currency from tokenData.
- `TransactionPaymentProcessor.processPayment()` takes an optional `currency` parameter; NFC passes `tokenData.currency`, QR stays unchanged.
- `TransactionProcessedEvent` gains optional `amount`/`currency` readonly fields. Backward compatible — QR's emitters just don't populate them.
- `PaymentSocketNotifier.emitPaymentResult` forwards `amount` (falling back to persisted transaction amount) and `currency` to the `payment.result` socket payload.

## Test plan

- [x] `yarn build` — clean.
- [x] `yarn test src/modules/nfc-payments/application/nfc-authorization.service.spec.ts src/modules/nfc-payments/application/nfc-transaction.builder.spec.ts src/modules/transactions/application/services/payment-socket-notifier.spec.ts` — 32/32 pass.
- [ ] Deploy + tap NFC card. Verify on the phone side: (a) socket receives `payment.processing` event before the final result, (b) `payment.result` arrives with `amount` and `currency` populated.

## Mobile coordinating PR

Mobile client PR incoming — will read `payment.processing` to transition into the new Processing state and use `amount`/`currency` from the socket payload instead of the fake defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)