### PR TITLE
fix(#33): mark PermissionsModule @Global() so bootstrap stops failing

### DIFF
--- a/src/modules/permissions/permissions.module.spec.ts
+++ b/src/modules/permissions/permissions.module.spec.ts
@@ -1,0 +1,27 @@
+import 'reflect-metadata';
+import { GLOBAL_MODULE_METADATA } from '@nestjs/common/constants';
+import { PermissionsModule } from './permissions.module';
+
+/**
+ * Issue #33 — el server fallaba en bootstrap porque AuditModule, RolesModule
+ * y UsersModule activaron @UseGuards(PermissionsGuard) en sus controllers
+ * sin tener PermissionsService disponible en su contexto. Importar
+ * PermissionsModule recíprocamente provocaría un ciclo (PermissionsModule
+ * ya importa AuditModule). La solución elegida es marcar PermissionsModule
+ * como @Global() para que sus exports sean visibles en cualquier módulo.
+ *
+ * Este test es una guarda de regresión: si alguien quita el @Global() sin
+ * proporcionar otra ruta de DI (por ejemplo APP_GUARD), bootstrap volverá
+ * a romperse.
+ */
+describe('PermissionsModule', () => {
+  it('está marcado como @Global() para evitar el ciclo Audit ↔ Permissions', () => {
+    // NestJS guarda el flag de módulo global con la metadata key
+    // GLOBAL_MODULE_METADATA = '__module:global__'.
+    const isGlobal = Reflect.getMetadata(
+      GLOBAL_MODULE_METADATA,
+      PermissionsModule,
+    );
+    expect(isGlobal).toBe(true);
+  });
+});

--- a/src/modules/permissions/permissions.module.ts
+++ b/src/modules/permissions/permissions.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 
 import { AuditModule } from '../audit/audit.module';
 import { CachingModule } from 'src/common/cache/cache.module';
@@ -10,18 +10,26 @@ import { PermissionsService } from './application/permissions.service';
 import { PermissionsGuard } from './infrastructure/guards/permissions.guard';
 
 /**
- * PermissionsModule - Módulo independiente para resolución y validación de permisos
+ * PermissionsModule - Módulo global para resolución y validación de permisos.
+ *
+ * Marcado `@Global()` para que cualquier controller que use
+ * `@UseGuards(PermissionsGuard)` o `@Permissions(...)` pueda resolver
+ * `PermissionsService` y `PermissionsGuard` sin necesidad de importar
+ * el módulo en cada feature module. Esto evita ciclos: `PermissionsModule`
+ * ya importa `AuditModule` (PermissionsGuard audita denials), por lo que
+ * un import recíproco — Audit → Permissions — provocaría un ciclo y
+ * obligaría a usar `forwardRef` en cada lugar.
  *
  * Responsabilidades:
  * - Resolver permisos de actores (usuarios, servicios)
  * - Validar permisos mediante PermissionsGuard
  * - Implementar caché de permisos
  *
- * Ventajas:
- * - Módulo autónomo sin dependencias circulares
- * - Reutilizable en cualquier módulo sin ciclos
- * - Inyección lazy de UsersService mediante ModuleRef
+ * Cubre issue #33 — el server fallaba en bootstrap porque AuditModule,
+ * RolesModule y UsersModule activaron `PermissionsGuard` en sus
+ * controllers sin tener `PermissionsService` disponible en su contexto.
  */
+@Global()
 @Module({
   imports: [AuditModule, CachingModule, RolesModule, UsersModule],
   providers: [PermissionsService, PermissionsGuard],

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## Summary
Closes #33. Tras PR #32, los controllers `AuditController`, `UsersController` y `RolesController` activaron `@UseGuards(JwtAuthGuard, PermissionsGuard)` sin que sus respectivos módulos tengan `PermissionsService` disponible en su contexto de DI. `yarn start:dev` y `yarn start:prod` abortaban con `UnknownDependenciesException`.

`PermissionsModule` ya importa `AuditModule` (el guard audita denials), así que un import recíproco crea un ciclo. La opción más quirúrgica que evita ciclos y `forwardRef` por todos lados es marcar `PermissionsModule` como `@Global()`.

## Changes
- `src/modules/permissions/permissions.module.ts`: `@Global()` + comentario explicando por qué.
- `src/modules/permissions/permissions.module.spec.ts`: guarda de regresión sobre `GLOBAL_MODULE_METADATA` para que cualquier futura desactivación del flag rompa CI antes que producción.
- `test/jest-e2e.json`: añadir `moduleNameMapper` para resolver `src/...` (prerequisito para que los e2e existentes corran).

## Test plan
- [x] `node dist/main.js` ya no lanza el error de DI; ahora sólo falla por Vault no levantado (ajeno al issue).
- [x] `yarn test` — 27 suites passing, 230 tests verde (+1 nuevo).
- [x] `yarn build` limpio.
- [ ] `yarn start:dev` con stack completo (Mongo + Redis + Vault) levanta el server.
- [ ] Walkthrough E2E con merchant `50952149` confirma que /system/audit, /system/users y /system/roles devuelven 403 sin perder el bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)