### PR TITLE
fix(modules): remove contact module from seed and deactivate stale rows (admin issue #5)

### DIFF
--- a/src/common/bootstrap/system-bootstrap.service.ts
+++ b/src/common/bootstrap/system-bootstrap.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
+import { computeStaleModuleIndicators } from 'src/modules/modules/seeds/compute-modules-plan';
 import { SYSTEM_MODULES } from 'src/modules/modules/seeds/system-modules';
 import { SYSTEM_ROLES } from 'src/modules/roles/seeds/system-roles';
 import { UsersService } from 'src/modules/users/application/users.service';
@@ -62,13 +63,27 @@ export class SystemBootstrapService implements OnModuleInit {
     this.logger.log('📦 PHASE 1: Bootstrap modules...');
 
     try {
-      const count = await this.moduleModel.countDocuments().exec();
-
-      if (count > 0) {
+      // Always reconcile: deactivate stale modules whose indicator no longer
+      // appears in SYSTEM_MODULES (e.g. when a frontend route is removed).
+      // The upsert below keeps existing-and-still-listed modules current.
+      const dbModules = await this.moduleModel
+        .find({}, { indicator: 1, _id: 0 })
+        .lean()
+        .exec();
+      const staleIndicators = computeStaleModuleIndicators(
+        dbModules.map((m: { indicator: string }) => m.indicator),
+        SYSTEM_MODULES.map((m) => m.indicator),
+      );
+      if (staleIndicators.length > 0) {
+        const result = await this.moduleModel
+          .updateMany(
+            { indicator: { $in: staleIndicators } },
+            { $set: { status: 'inactive' } },
+          )
+          .exec();
         this.logger.log(
-          `   ⏭️  Modules collection already has ${count} documents - skipping seed`,
+          `   🧹 Deactivated ${result.modifiedCount ?? 0} stale module(s): ${staleIndicators.join(', ')}`,
         );
-        return;
       }
 
       let seedCount = 0;

--- a/src/modules/modules/seeds/compute-modules-plan.spec.ts
+++ b/src/modules/modules/seeds/compute-modules-plan.spec.ts
@@ -1,0 +1,27 @@
+import { computeStaleModuleIndicators } from './compute-modules-plan';
+
+describe('computeStaleModuleIndicators', () => {
+  it('returns indicators present in DB but missing from the current seed catalog', () => {
+    const dbIndicators = ['dashboard', 'transactions', 'contact', 'old-feature'];
+    const seedIndicators = ['dashboard', 'transactions'];
+
+    const stale = computeStaleModuleIndicators(dbIndicators, seedIndicators);
+
+    expect(stale.sort()).toEqual(['contact', 'old-feature']);
+  });
+
+  it('returns an empty array when DB and seed agree', () => {
+    const stale = computeStaleModuleIndicators(['a', 'b'], ['a', 'b']);
+    expect(stale).toEqual([]);
+  });
+
+  it('returns an empty array when DB has fewer modules than seed (new modules to add)', () => {
+    const stale = computeStaleModuleIndicators(['a'], ['a', 'b']);
+    expect(stale).toEqual([]);
+  });
+
+  it('handles duplicate indicators in the DB list defensively', () => {
+    const stale = computeStaleModuleIndicators(['a', 'a', 'b'], ['a']);
+    expect(stale.sort()).toEqual(['b']);
+  });
+});

--- a/src/modules/modules/seeds/compute-modules-plan.ts
+++ b/src/modules/modules/seeds/compute-modules-plan.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns the set of module indicators that exist in the DB but are no longer
+ * present in the current seed catalog. The bootstrap layer uses this list to
+ * mark such modules as `inactive`, so they stop appearing in navigation when
+ * a module is intentionally removed from {@link SYSTEM_MODULES} (e.g. when its
+ * frontend route was deleted — see admin issue #5 for `contact`).
+ */
+export function computeStaleModuleIndicators(
+  dbIndicators: readonly string[],
+  seedIndicators: readonly string[],
+): string[] {
+  const seedSet = new Set(seedIndicators);
+  const stale = new Set<string>();
+  for (const indicator of dbIndicators) {
+    if (!seedSet.has(indicator)) {
+      stale.add(indicator);
+    }
+  }
+  return Array.from(stale);
+}

--- a/src/modules/modules/seeds/system-modules.spec.ts
+++ b/src/modules/modules/seeds/system-modules.spec.ts
@@ -1,0 +1,16 @@
+import { SYSTEM_MODULES, getSystemModuleByIndicator } from './system-modules';
+
+describe('SYSTEM_MODULES seed catalog', () => {
+  it('does not expose an active "contact" module (admin app has no /system/contact route, see admin issue #5)', () => {
+    const contactModule = getSystemModuleByIndicator('contact');
+
+    if (contactModule !== undefined) {
+      expect(contactModule.status).not.toBe('active');
+    }
+
+    const activeContactInExport = SYSTEM_MODULES.find(
+      (m) => m.indicator === 'contact' && m.status === 'active',
+    );
+    expect(activeContactInExport).toBeUndefined();
+  });
+});

--- a/src/modules/modules/seeds/system-modules.ts
+++ b/src/modules/modules/seeds/system-modules.ts
@@ -647,28 +647,9 @@ const CHANGELOG_MODULE = new ModuleEntity({
   type: ModuleType.basic,
 });
 
-const CONTACT_MODULE = new ModuleEntity({
-  order: 8,
-  parent: 'system',
-  indicator: 'contact',
-  name: 'Contact',
-  description: 'Información de contacto y formulario de comunicación.',
-  icon: 'mail',
-  actions: ['read'],
-  permissions: createPermissionsFromActions('contact', 'Contact', [
-    {
-      action: 'read',
-      id: 'ct_r',
-      name: 'Ver Contacto',
-      description:
-        'Acceso a información de contacto y formularios de comunicación.',
-      enabled: true,
-    },
-  ]),
-  status: 'active',
-  isSystem: true,
-  type: ModuleType.basic,
-});
+// CONTACT_MODULE removed (admin issue #5): the admin app has no /system/contact
+// route, so the module produced an NG04002 error when navigated to. Re-add when
+// the frontend route exists.
 
 
 // ============================================================================
@@ -704,7 +685,8 @@ export const SYSTEM_MODULES: ModuleEntity[] = [
   USERS_MODULE,
 
   CHANGELOG_MODULE,
-  CONTACT_MODULE,
+  // CONTACT_MODULE removed — admin app has no /system/contact route (admin issue #5).
+  // Re-add only when the route exists on the frontend.
   // DOCUMENTATION_MODULE,
   // SUPPORT_MODULE,
 


### PR DESCRIPTION
## Summary

- Removes `CONTACT_MODULE` from `SYSTEM_MODULES` (admin app has no `/system/contact` route — produced `NG04002` error).
- Adds a pure helper `computeStaleModuleIndicators` with unit tests.
- Bootstrap PHASE 1 now always reconciles: any module present in the DB but missing from the seed catalog is flipped to `status: 'inactive'`, then current modules are upserted as before.
- Adds a guardrail spec on `SYSTEM_MODULES` so we don't accidentally re-add a module that lacks a frontend route.

## Why

Bootstrap previously short-circuited when `count > 0`, so removing a module from the seed had no effect on existing environments. Production still served the contact entry from `/api_053/modules/navigation`, and the admin app threw `NG04002: 'system/contact'` on click.

## Test plan

- [x] yarn test --testPathPatterns=system-modules
- [x] yarn test --testPathPatterns=compute-modules-plan (4 cases)
- [x] yarn test full suite (235 passed)
- [x] yarn build clean
- [ ] Post-deploy: confirm `GET /api_053/modules/navigation` no longer returns contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)