### PR TITLE
fix(auth): logout limpia cookies con atributos que coinciden con set (#36)

### DIFF
--- a/src/modules/auth/infrastructure/controllers/auth.controller.logout.spec.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.logout.spec.ts
@@ -68,10 +68,9 @@ describe('AuthController.logout — clearCookie atributos coinciden con getCooki
 
     await controller.logout(res);
 
+    expect(calls).toHaveLength(3);
     const byName = Object.fromEntries(calls.map((c) => [c.name, c.options]));
-    expect(byName['refresh_token'].domain).toBe('.clasica.xyz');
-    expect(byName['refresh_token'].secure).toBe(true);
-    expect(byName['refresh_token'].sameSite).toBe('none');
+    assertMatches(byName['refresh_token'], cfg.refresh_token);
     // Path debe ser '/', no '/auth/refresh' como antes del fix
     expect(byName['refresh_token'].path).toBe('/');
     assertMatches(byName['access_token'], cfg.access_token);

--- a/src/modules/auth/infrastructure/controllers/auth.controller.logout.spec.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.logout.spec.ts
@@ -1,0 +1,80 @@
+import 'reflect-metadata';
+import type { Response, CookieOptions } from 'express';
+import { AuthController } from './auth.controller';
+import { getCookieConfig } from 'src/config/cookie.config';
+
+/**
+ * Issue #36 — logout dejaba la cookie viva en el navegador porque clearCookie
+ * usaba atributos (Path/Domain/SameSite/Secure) distintos a los del Set-Cookie
+ * original. Esta suite cubre dev y prod para evitar regresión.
+ */
+describe('AuthController.logout — clearCookie atributos coinciden con getCookieConfig', () => {
+  const buildController = (): AuthController =>
+    new AuthController({} as never, {} as never);
+
+  const buildRes = () => {
+    const calls: Array<{ name: string; options: CookieOptions }> = [];
+    const res = {
+      clearCookie: jest.fn((name: string, options: CookieOptions) => {
+        calls.push({ name, options });
+        return res;
+      }),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+    return { res, calls };
+  };
+
+  const assertMatches = (
+    actual: CookieOptions | undefined,
+    expected: CookieOptions,
+  ) => {
+    expect(actual).toBeDefined();
+    expect(actual!.path).toBe(expected.path);
+    expect(actual!.domain).toBe(expected.domain);
+    expect(actual!.sameSite).toBe(expected.sameSite);
+    expect(actual!.secure).toBe(expected.secure);
+    expect(actual!.httpOnly).toBe(expected.httpOnly);
+  };
+
+  const originalEnv = process.env;
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('en development limpia las tres cookies con los mismos atributos con que se setean', async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'development' };
+    const cfg = getCookieConfig();
+    const controller = buildController();
+    const { res, calls } = buildRes();
+
+    await controller.logout(res);
+
+    expect(calls).toHaveLength(3);
+    const byName = Object.fromEntries(calls.map((c) => [c.name, c.options]));
+    assertMatches(byName['access_token'], cfg.access_token);
+    assertMatches(byName['refresh_token'], cfg.refresh_token);
+    assertMatches(byName['XSRF-TOKEN'], cfg.csrf_token);
+  });
+
+  it('en production con COOKIE_DOMAIN limpia incluyendo domain/secure/sameSite=none', async () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      COOKIE_DOMAIN: '.clasica.xyz',
+    };
+    const cfg = getCookieConfig();
+    const controller = buildController();
+    const { res, calls } = buildRes();
+
+    await controller.logout(res);
+
+    const byName = Object.fromEntries(calls.map((c) => [c.name, c.options]));
+    expect(byName['refresh_token'].domain).toBe('.clasica.xyz');
+    expect(byName['refresh_token'].secure).toBe(true);
+    expect(byName['refresh_token'].sameSite).toBe('none');
+    // Path debe ser '/', no '/auth/refresh' como antes del fix
+    expect(byName['refresh_token'].path).toBe('/');
+    assertMatches(byName['access_token'], cfg.access_token);
+    assertMatches(byName['XSRF-TOKEN'], cfg.csrf_token);
+  });
+});

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -375,10 +375,21 @@ export class AuthController {
     description: 'Sesión cerrada exitosamente',
   })
   async logout(@Res() res: Response): Promise<Response> {
-    // Limpiar cookies
-    res.clearCookie('access_token', { path: '/' });
-    res.clearCookie('refresh_token', { path: '/auth/refresh' });
-    res.clearCookie('XSRF-TOKEN', { path: '/' });
+    // Para que el navegador realmente elimine la cookie, los atributos
+    // Path / Domain / SameSite / Secure / HttpOnly deben coincidir con los
+    // usados al setearla. Reutilizamos la config de origen.
+    const cfg = getCookieConfig();
+    const clearOpts = (o: import('express').CookieOptions): import('express').CookieOptions => ({
+      httpOnly: o.httpOnly,
+      secure: o.secure,
+      sameSite: o.sameSite,
+      domain: o.domain,
+      path: o.path,
+    });
+
+    res.clearCookie('access_token', clearOpts(cfg.access_token));
+    res.clearCookie('refresh_token', clearOpts(cfg.refresh_token));
+    res.clearCookie('XSRF-TOKEN', clearOpts(cfg.csrf_token));
 
     return res.json({
       success: true,


### PR DESCRIPTION
## Summary

- POST /auth/logout ahora invoca clearCookie reutilizando getCookieConfig(), así Path/Domain/SameSite/Secure/HttpOnly coinciden con el Set-Cookie original y el navegador realmente elimina las cookies.
- Antes: refresh_token se seteaba con path '/' pero se limpiaba con path '/auth/refresh' (y en prod faltaban domain, sameSite 'none', secure true), así que la cookie sobrevivía y al recargar la sesión revivía vía /auth/refresh.
- Test unitario que cubre dev (sin domain) y prod (COOKIE_DOMAIN definido, SameSite=None; Secure).

Closes #36

## Test plan

- [x] yarn test --testPathPatterns=auth.controller.logout (2 passing)
- [x] yarn build clean
- [x] QA en admin.clasica.xyz: login → logout → F5 debe quedar en /login
- [x] DevTools cookies: tras /auth/logout no aparecen access_token, refresh_token, XSRF-TOKEN
- [x] POST /auth/refresh posterior responde 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)