### PR TITLE
fix(vault): fallback a AppRole para que un VAULT_TOKEN expirado no cause crash-loop (#38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,11 @@ VAULT_ADDR=
 VAULT_KV_MOUNT=
 VAULT_NAMESPACE=
 # Vault auth: provide EITHER the AppRole pair (recommended) OR a static
-# VAULT_TOKEN (legacy). In production prefer AppRole and leave VAULT_TOKEN
-# empty: a static token expires and is not self-recoverable. AppRole
+# VAULT_TOKEN (legacy). At least one mode is required.
+# In production prefer AppRole-only and leave VAULT_TOKEN empty: AppRole
 # credentials do not expire and the app re-authenticates automatically.
+# A static VAULT_TOKEN expires; the app only recovers from that on its own
+# if AppRole credentials are also present (it re-logs in on 401/403).
 VAULT_ROLE_ID=
 VAULT_SECRET_ID=
 VAULT_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ SMS_TOKEN=
 VAULT_ADDR=
 VAULT_KV_MOUNT=
 VAULT_NAMESPACE=
+# Vault auth: provide EITHER the AppRole pair (recommended) OR a static
+# VAULT_TOKEN (legacy). In production prefer AppRole and leave VAULT_TOKEN
+# empty: a static token expires and is not self-recoverable. AppRole
+# credentials do not expire and the app re-authenticates automatically.
 VAULT_ROLE_ID=
 VAULT_SECRET_ID=
 VAULT_TOKEN=

--- a/src/config/config.schema.spec.ts
+++ b/src/config/config.schema.spec.ts
@@ -1,0 +1,65 @@
+import { configValidationSchema } from './config.schema';
+
+/**
+ * Issue #38 — VAULT_TOKEN era required(), forzando un token estático que al
+ * expirar dejaba api-classical en crash-loop pese a tener AppRole válido.
+ * El schema debe aceptar cualquiera de los dos modos de auth.
+ */
+describe('configValidationSchema — Vault auth modes', () => {
+  const baseEnv: Record<string, string> = {
+    API_KEY: 'k',
+    APP_NAME: 'classical-server-app',
+    DB_HOST: 'mongodb://localhost:27017/fx',
+    ENVIRONMENT: 'DEVELOPMENT',
+    JWT_SECRET: 's',
+    PORT: '9053',
+    REDIS_HOST: 'localhost',
+    REDIS_PASSWORD: 'p',
+    REDIS_PORT: '6379',
+    REDIS_ROOT_KEY: 'app_',
+    REDIS_TTL: '3600',
+    SA_EMAIL: 'sa@example.com',
+    SA_PWD: 'pwd',
+    SGT_AES_KEY: 'aes',
+    SGT_AES_IV: 'iv',
+    SGT_URL: 'https://sgt.example',
+    SGT_HMAC_SECRET: 'hmac',
+    SGT_CLIENT_ID: 'cid',
+    SMS_API_URL: 'https://sms.example',
+    SMS_TOKEN: 'tok',
+    VAULT_ADDR: 'https://vault.example',
+    VAULT_KV_MOUNT: 'classical',
+    VAULT_NAMESPACE: 'admin',
+  };
+
+  it('accepts AppRole credentials without VAULT_TOKEN', () => {
+    const { error } = configValidationSchema.validate({
+      ...baseEnv,
+      VAULT_ROLE_ID: 'role-123',
+      VAULT_SECRET_ID: 'secret-123',
+    });
+    expect(error).toBeUndefined();
+  });
+
+  it('accepts a static VAULT_TOKEN without AppRole credentials', () => {
+    const { error } = configValidationSchema.validate({
+      ...baseEnv,
+      VAULT_TOKEN: 'hvs.legacy-token',
+    });
+    expect(error).toBeUndefined();
+  });
+
+  it('rejects when neither VAULT_TOKEN nor AppRole credentials are present', () => {
+    const { error } = configValidationSchema.validate({ ...baseEnv });
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('Vault auth misconfigured');
+  });
+
+  it('rejects when only VAULT_ROLE_ID is present (incomplete AppRole)', () => {
+    const { error } = configValidationSchema.validate({
+      ...baseEnv,
+      VAULT_ROLE_ID: 'role-123',
+    });
+    expect(error).toBeDefined();
+  });
+});

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -32,10 +32,10 @@ type EnvVars = {
   VAULT_ADDR: string;
   VAULT_KV_MOUNT: string;
   VAULT_NAMESPACE: string;
-  VAULT_ROLE_ID: string;
-  VAULT_SECRET_ID: string;
+  VAULT_ROLE_ID?: string;
+  VAULT_SECRET_ID?: string;
   VAULT_SECRET_ID_WRAPPED?: string;
-  VAULT_TOKEN: string;
+  VAULT_TOKEN?: string;
   VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC?: number;
 };
 
@@ -70,13 +70,26 @@ export const configValidationSchema: joi.ObjectSchema = joi
     VAULT_ADDR: joi.string().required(),
     VAULT_KV_MOUNT: joi.string().required(),
     VAULT_NAMESPACE: joi.string().required(),
-    VAULT_ROLE_ID: joi.string().required(),
-    VAULT_SECRET_ID: joi.string().required(),
+    VAULT_ROLE_ID: joi.string().optional().allow(''),
+    VAULT_SECRET_ID: joi.string().optional().allow(''),
     VAULT_SECRET_ID_WRAPPED: joi.string().optional(),
-    VAULT_TOKEN: joi.string().required(),
+    VAULT_TOKEN: joi.string().optional().allow(''),
     VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC: joi.number().optional(),
   })
-  .unknown(true);
+  .unknown(true)
+  // Vault auth: require either a static VAULT_TOKEN (legacy) or the AppRole
+  // pair VAULT_ROLE_ID + VAULT_SECRET_ID (recommended). See issue #38.
+  .custom((value, helpers) => {
+    const hasToken = !!value.VAULT_TOKEN;
+    const hasAppRole = !!value.VAULT_ROLE_ID && !!value.VAULT_SECRET_ID;
+    if (!hasToken && !hasAppRole) {
+      return helpers.message({
+        custom:
+          'Vault auth misconfigured: set VAULT_TOKEN or (VAULT_ROLE_ID + VAULT_SECRET_ID)',
+      });
+    }
+    return value;
+  });
 
 // Validar las variables de entorno
 const validationResult = configValidationSchema.validate(process.env, {

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -1,46 +1,12 @@
 // Third´s Modules
 import * as joi from 'joi';
-import 'dotenv/config';
 
 /**
- * Variables de entorno
- */
-type EnvVars = {
-  API_KEY: string;
-  APP_NAME: string;
-  DB_HOST: string;
-  ENVIRONMENT: string;
-  FIREBASE_CREDENTIALS?: string;
-  JWT_SECRET: string;
-  PORT: number;
-  REDIS_HOST: string;
-  REDIS_PASSWORD: string;
-  REDIS_PORT: number;
-  REDIS_ROOT_KEY: string;
-  REDIS_TTL: number;
-  SA_EMAIL: string;
-  SA_PWD: string;
-  SEED_ENABLED?: string;
-  SEED_ENABLED_VAULT?: string;
-  SGT_AES_KEY: string;
-  SGT_AES_IV: string;
-  SGT_URL: string;
-  SGT_HMAC_SECRET: string;
-  SGT_CLIENT_ID: string;
-  SMS_API_URL: string;
-  SMS_TOKEN: string;
-  VAULT_ADDR: string;
-  VAULT_KV_MOUNT: string;
-  VAULT_NAMESPACE: string;
-  VAULT_ROLE_ID?: string;
-  VAULT_SECRET_ID?: string;
-  VAULT_SECRET_ID_WRAPPED?: string;
-  VAULT_TOKEN?: string;
-  VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC?: number;
-};
-
-/**
- * Validate env variables
+ * Joi schema for environment variable validation.
+ *
+ * This module is intentionally side-effect-free: it only exports the schema.
+ * Validation of `process.env` runs once, via NestJS `ConfigModule`
+ * (`validationSchema: configValidationSchema` in `app.module.ts`).
  */
 export const configValidationSchema: joi.ObjectSchema = joi
   .object({
@@ -72,73 +38,23 @@ export const configValidationSchema: joi.ObjectSchema = joi
     VAULT_NAMESPACE: joi.string().required(),
     VAULT_ROLE_ID: joi.string().optional().allow(''),
     VAULT_SECRET_ID: joi.string().optional().allow(''),
-    VAULT_SECRET_ID_WRAPPED: joi.string().optional(),
+    VAULT_SECRET_ID_WRAPPED: joi.string().optional().allow(''),
     VAULT_TOKEN: joi.string().optional().allow(''),
     VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC: joi.number().optional(),
   })
   .unknown(true)
   // Vault auth: require either a static VAULT_TOKEN (legacy) or the AppRole
-  // pair VAULT_ROLE_ID + VAULT_SECRET_ID (recommended). See issue #38.
+  // pair VAULT_ROLE_ID + VAULT_SECRET_ID (recommended). VAULT_SECRET_ID_WRAPPED
+  // counts as a SecretID for this purpose. See issue #38.
   .custom((value, helpers) => {
     const hasToken = !!value.VAULT_TOKEN;
-    const hasAppRole = !!value.VAULT_ROLE_ID && !!value.VAULT_SECRET_ID;
+    const hasAppRole =
+      !!value.VAULT_ROLE_ID &&
+      (!!value.VAULT_SECRET_ID || !!value.VAULT_SECRET_ID_WRAPPED);
     if (!hasToken && !hasAppRole) {
-      return helpers.message({
-        custom:
-          'Vault auth misconfigured: set VAULT_TOKEN or (VAULT_ROLE_ID + VAULT_SECRET_ID)',
-      });
+      return helpers.message(
+        'Vault auth misconfigured: set VAULT_TOKEN or (VAULT_ROLE_ID + VAULT_SECRET_ID)' as never,
+      );
     }
     return value;
   });
-
-// Validar las variables de entorno
-const validationResult = configValidationSchema.validate(process.env, {
-  abortEarly: false,
-});
-
-// Lanzar error si hay un error en la validación
-if (validationResult.error) {
-  throw new Error(`Config validation error: ${validationResult.error.message}`);
-}
-
-/**
- * Variables de entorno
- */
-const envVars: EnvVars = validationResult.value as unknown as EnvVars;
-
-/**
- * Exportar las variables de number
- */
-export const envs = {
-  API_KEY: envVars.API_KEY,
-  APP_NAME: envVars.APP_NAME,
-  DB_HOST: envVars.DB_HOST,
-  ENVIRONMENT: envVars.ENVIRONMENT,
-  FIREBASE_CREDENTIALS: envVars.FIREBASE_CREDENTIALS,
-  JWT_SECRET: envVars.JWT_SECRET,
-  PORT: envVars.PORT,
-  REDIS_HOST: envVars.REDIS_HOST,
-  REDIS_PASSWORD: envVars.REDIS_PASSWORD,
-  REDIS_PORT: envVars.REDIS_PORT,
-  REDIS_ROOT_KEY: envVars.REDIS_ROOT_KEY,
-  REDIS_TTL: envVars.REDIS_TTL,
-  SA_EMAIL: envVars.SA_EMAIL,
-  SA_PWD: envVars.SA_PWD,
-  SEED_ENABLED: envVars.SEED_ENABLED,
-  SEED_ENABLED_VAULT: envVars.SEED_ENABLED_VAULT,
-  SGT_AES_KEY: envVars.SGT_AES_KEY,
-  SGT_AES_IV: envVars.SGT_AES_IV,
-  SGT_URL: envVars.SGT_URL,
-  SGT_HMAC_SECRET: envVars.SGT_HMAC_SECRET,
-  SGT_CLIENT_ID: envVars.SGT_CLIENT_ID,
-  SMS_API_URL: envVars.SMS_API_URL,
-  SMS_TOKEN: envVars.SMS_TOKEN,
-  VAULT_ADDR: envVars.VAULT_ADDR,
-  VAULT_KV_MOUNT: envVars.VAULT_KV_MOUNT,
-  VAULT_NAMESPACE: envVars.VAULT_NAMESPACE,
-  VAULT_ROLE_ID: envVars.VAULT_ROLE_ID,
-  VAULT_SECRET_ID: envVars.VAULT_SECRET_ID,
-  VAULT_SECRET_ID_WRAPPED: envVars.VAULT_SECRET_ID_WRAPPED,
-  VAULT_TOKEN: envVars.VAULT_TOKEN,
-  VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC: envVars.VAULT_TOKEN_RENEW_SAFETY_WINDOW_SEC,
-};

--- a/src/modules/vault/infrastructure/adapters/vault-http.adapter.spec.ts
+++ b/src/modules/vault/infrastructure/adapters/vault-http.adapter.spec.ts
@@ -1,0 +1,154 @@
+import axios from 'axios';
+import { VaultHttpAdapter } from './vault-http.adapter';
+
+jest.mock('axios');
+
+/**
+ * Issue #38 — el VAULT_TOKEN estático asumía 24h de TTL a ciegas y nunca
+ * caía a AppRole. Esta suite verifica:
+ *  - onModuleInit descubre el TTL real vía lookup-self
+ *  - operaciones KV reintentan vía AppRole ante 401/403
+ */
+describe('VaultHttpAdapter — issue #38 token lifecycle', () => {
+  const FRESH_TOKEN = 'hvs.fresh-approle-token';
+  const STATIC_TOKEN = 'hvs.static-token';
+
+  type MockHttp = {
+    get: jest.Mock;
+    post: jest.Mock;
+    delete: jest.Mock;
+    defaults: { headers: { common: Record<string, string> } };
+  };
+
+  let http: MockHttp;
+
+  const buildConfig = (overrides: Record<string, unknown> = {}) => {
+    const values: Record<string, unknown> = {
+      VAULT_ADDR: 'https://vault.example',
+      VAULT_NAMESPACE: 'admin',
+      VAULT_KV_MOUNT: 'classical',
+      VAULT_ROLE_ID: 'role-123',
+      VAULT_SECRET_ID: 'secret-123',
+      VAULT_TOKEN: STATIC_TOKEN,
+      ...overrides,
+    };
+    return { get: <T>(k: string): T => values[k] as T };
+  };
+
+  const buildAdapter = (configOverrides: Record<string, unknown> = {}) =>
+    new VaultHttpAdapter(
+      buildConfig(configOverrides) as never,
+      { emit: jest.fn() } as never,
+      { getRequestId: () => 'req-1' } as never,
+    );
+
+  /** axios error shaped like a real Vault HTTP failure */
+  const vaultHttpError = (status: number) => ({
+    isAxiosError: true,
+    message: `Request failed with status code ${status}`,
+    response: { status, data: { errors: ['permission denied', 'invalid token'] } },
+  });
+
+  beforeEach(() => {
+    http = {
+      get: jest.fn(),
+      post: jest.fn(),
+      delete: jest.fn(),
+      defaults: { headers: { common: {} } },
+    };
+    (axios.create as jest.Mock).mockReturnValue(http);
+    (axios.isAxiosError as unknown as jest.Mock).mockImplementation(
+      (e: unknown) => !!(e as { isAxiosError?: boolean })?.isAxiosError,
+    );
+  });
+
+  it('falls back to AppRole login when the static token is already expired', async () => {
+    // lookup-self reports a 1-second TTL — token is effectively dead.
+    http.get.mockImplementation((url: string) => {
+      if (url.includes('lookup-self')) {
+        return Promise.resolve({ data: { data: { ttl: 1, renewable: false } } });
+      }
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    // AppRole login succeeds with a fresh token.
+    http.post.mockImplementation((url: string) => {
+      if (url.includes('approle/login')) {
+        return Promise.resolve({
+          data: {
+            auth: {
+              client_token: FRESH_TOKEN,
+              token_renewable: true,
+              token_duration: 3600,
+            },
+          },
+        });
+      }
+      return Promise.reject(new Error(`unexpected POST ${url}`));
+    });
+
+    const adapter = buildAdapter();
+    await adapter.onModuleInit();
+
+    const tokenResult = await adapter.getToken();
+
+    expect(tokenResult.isSuccess).toBe(true);
+    expect(tokenResult.getValue()).toBe(FRESH_TOKEN);
+  });
+
+  it('writeKV retries via AppRole login when the first attempt returns 403', async () => {
+    let kvWriteAttempts = 0;
+    http.post.mockImplementation((url: string) => {
+      if (url.includes('approle/login')) {
+        return Promise.resolve({
+          data: {
+            auth: {
+              client_token: FRESH_TOKEN,
+              token_renewable: true,
+              token_duration: 3600,
+            },
+          },
+        });
+      }
+      // KV write path: first attempt fails 403, retry succeeds.
+      kvWriteAttempts += 1;
+      if (kvWriteAttempts === 1) {
+        return Promise.reject(vaultHttpError(403));
+      }
+      return Promise.resolve({ data: { data: { value: 'stored' } } });
+    });
+
+    const adapter = buildAdapter();
+    // No onModuleInit: constructor leaves the static token "valid" by clock,
+    // so getToken() returns it and the 403 only surfaces on the HTTP call.
+    const result = await adapter.writeKV('admin/jwks-private/jwks-default', {
+      value: 'pem',
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(kvWriteAttempts).toBe(2);
+    expect(
+      http.post.mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes('approle/login'),
+      ),
+    ).toBe(true);
+  });
+
+  it('writeKV does not retry when no AppRole credentials are configured', async () => {
+    let kvWriteAttempts = 0;
+    http.post.mockImplementation((url: string) => {
+      if (url.includes('approle/login')) {
+        return Promise.reject(new Error('login should not be called'));
+      }
+      kvWriteAttempts += 1;
+      return Promise.reject(vaultHttpError(403));
+    });
+
+    const adapter = buildAdapter({ VAULT_ROLE_ID: '', VAULT_SECRET_ID: '' });
+    const result = await adapter.writeKV('admin/jwks-private/jwks-default', {
+      value: 'pem',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(kvWriteAttempts).toBe(1);
+  });
+});

--- a/src/modules/vault/infrastructure/adapters/vault-http.adapter.spec.ts
+++ b/src/modules/vault/infrastructure/adapters/vault-http.adapter.spec.ts
@@ -120,7 +120,7 @@ describe('VaultHttpAdapter — issue #38 token lifecycle', () => {
     const adapter = buildAdapter();
     // No onModuleInit: constructor leaves the static token "valid" by clock,
     // so getToken() returns it and the 403 only surfaces on the HTTP call.
-    const result = await adapter.writeKV('admin/jwks-private/jwks-default', {
+    const result = await adapter.writeKV('jwks-private/jwks-default', {
       value: 'pem',
     });
 
@@ -144,11 +144,62 @@ describe('VaultHttpAdapter — issue #38 token lifecycle', () => {
     });
 
     const adapter = buildAdapter({ VAULT_ROLE_ID: '', VAULT_SECRET_ID: '' });
-    const result = await adapter.writeKV('admin/jwks-private/jwks-default', {
+    const result = await adapter.writeKV('jwks-private/jwks-default', {
       value: 'pem',
     });
 
     expect(result.isSuccess).toBe(false);
     expect(kvWriteAttempts).toBe(1);
+  });
+
+  it('rejects a KV path containing path traversal without issuing any request', async () => {
+    const adapter = buildAdapter();
+
+    const result = await adapter.writeKV('../../sys/policies/acl/root', {
+      value: 'pem',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-expiring static token (lookup-self ttl=0) as valid', async () => {
+    http.get.mockImplementation((url: string) => {
+      if (url.includes('lookup-self')) {
+        return Promise.resolve({ data: { data: { ttl: 0, renewable: false } } });
+      }
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    http.post.mockImplementation((url: string) =>
+      Promise.reject(new Error(`no HTTP call expected, got ${url}`)),
+    );
+
+    const adapter = buildAdapter();
+    await adapter.onModuleInit();
+
+    const tokenResult = await adapter.getToken();
+
+    expect(tokenResult.isSuccess).toBe(true);
+    expect(tokenResult.getValue()).toBe(STATIC_TOKEN);
+  });
+
+  it('keeps the provisional token when lookup-self fails with a network error', async () => {
+    http.get.mockImplementation((url: string) => {
+      if (url.includes('lookup-self')) {
+        return Promise.reject(new Error('ECONNREFUSED'));
+      }
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    http.post.mockImplementation((url: string) =>
+      Promise.reject(new Error(`no login expected, got ${url}`)),
+    );
+
+    const adapter = buildAdapter();
+    await adapter.onModuleInit();
+
+    const tokenResult = await adapter.getToken();
+
+    expect(tokenResult.isSuccess).toBe(true);
+    expect(tokenResult.getValue()).toBe(STATIC_TOKEN);
   });
 });

--- a/src/modules/vault/infrastructure/adapters/vault-http.adapter.ts
+++ b/src/modules/vault/infrastructure/adapters/vault-http.adapter.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import axios, { AxiosInstance } from 'axios';
@@ -18,13 +18,14 @@ import { Result } from 'src/common/types/result.type';
  * Handles token lifecycle (login, renew, unwrap wrapped tokens).
  */
 @Injectable()
-export class VaultHttpAdapter implements IVaultClient {
+export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
   private readonly logger = new Logger(VaultHttpAdapter.name);
   private readonly httpClient: AxiosInstance;
 
   private token: string | null = null;
   private tokenExpire: Date | null = null;
   private isRenewable = false;
+  private vaultToken: string | undefined;
 
   private readonly vaultAddr: string;
   private readonly vaultNamespace: string | undefined;
@@ -34,7 +35,6 @@ export class VaultHttpAdapter implements IVaultClient {
   private secretId: string | undefined;
   private readonly secretIdWrapped: string | undefined;
   private readonly tokenRenewSafetyWindowSec: number;
-  private readonly vaultToken: string | undefined;
 
   constructor(
     private readonly config: ConfigService,
@@ -60,14 +60,53 @@ export class VaultHttpAdapter implements IVaultClient {
       },
     });
 
-    // Si hay un token de Vault configurado, usarlo directamente
+    // Si hay un token de Vault configurado, usarlo provisionalmente.
+    // onModuleInit() verificará su TTL real vía lookup-self.
     if (this.vaultToken) {
       this.token = this.vaultToken;
-      this.tokenExpire = new Date(Date.now() + 86400 * 1000); // 24 horas
-      this.isRenewable = false; // No renovable, es un token de raíz
+      this.tokenExpire = new Date(Date.now() + 86400 * 1000); // provisional
+      this.isRenewable = false;
       this.httpClient.defaults.headers.common['X-Vault-Token'] =
         this.vaultToken;
-      this.logger.log('Using pre-configured Vault token');
+    }
+  }
+
+  /**
+   * Verifica el VAULT_TOKEN estático contra Vault para descubrir su TTL y
+   * si es renovable. Sin esto el adapter asumía 24h a ciegas: un token con
+   * TTL menor expiraba en Vault mientras el adapter lo creía vigente, sin
+   * caer nunca a AppRole (issue #38).
+   */
+  async onModuleInit(): Promise<void> {
+    if (!this.vaultToken) {
+      return;
+    }
+    try {
+      const resp = await this.httpClient.get<{
+        data?: { ttl?: number; renewable?: boolean };
+      }>('/v1/auth/token/lookup-self', {
+        headers: { 'X-Vault-Token': this.vaultToken },
+      });
+      const data = resp.data?.data ?? {};
+      const ttlSec = data.ttl ?? 0;
+      this.token = this.vaultToken;
+      this.tokenExpire = new Date(Date.now() + ttlSec * 1000);
+      this.isRenewable = !!data.renewable;
+      this.httpClient.defaults.headers.common['X-Vault-Token'] =
+        this.vaultToken;
+      this.logger.log(
+        `Using pre-configured Vault token (ttl=${ttlSec}s renewable=${this.isRenewable})`,
+      );
+    } catch {
+      // Token inválido/expirado: descartarlo para que getToken() haga
+      // login() vía AppRole en la primera operación.
+      this.logger.warn(
+        'Pre-configured VAULT_TOKEN invalid or expired; falling back to AppRole',
+      );
+      this.vaultToken = undefined;
+      this.token = null;
+      this.tokenExpire = null;
+      delete this.httpClient.defaults.headers.common['X-Vault-Token'];
     }
   }
 
@@ -135,7 +174,9 @@ export class VaultHttpAdapter implements IVaultClient {
       }
 
       const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${path}`;
-      const response = await this.httpClient.get<VaultKVData>(fullPath);
+      const response = await this.withAppRoleFallback(() =>
+        this.httpClient.get<VaultKVData>(fullPath),
+      );
       this.logger.log(`Read secret from Vault: ${path}`);
       this.emitEvent('read', path, 'completed');
 
@@ -159,9 +200,9 @@ export class VaultHttpAdapter implements IVaultClient {
       }
 
       const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${path}`;
-      const response = await this.httpClient.post<VaultKVData>(fullPath, {
-        data,
-      });
+      const response = await this.withAppRoleFallback(() =>
+        this.httpClient.post<VaultKVData>(fullPath, { data }),
+      );
 
       this.logger.log(`Wrote secret to Vault: ${path}`);
       this.emitEvent('write', path, 'completed');
@@ -183,7 +224,7 @@ export class VaultHttpAdapter implements IVaultClient {
       }
 
       const fullPath = `/v1/${this.kvMount}/metadata/${this.vaultNamespace}/${path}`;
-      await this.httpClient.delete(fullPath);
+      await this.withAppRoleFallback(() => this.httpClient.delete(fullPath));
 
       this.logger.log(`Deleted secret from Vault: ${path}`);
       this.emitEvent('delete', path, 'completed');
@@ -229,6 +270,36 @@ export class VaultHttpAdapter implements IVaultClient {
   /**
    * Private helper methods
    */
+
+  /**
+   * Runs a Vault HTTP operation; if it fails with 401/403 and AppRole
+   * credentials are configured, re-authenticates via AppRole and retries
+   * the operation once. Without this, a token that expires mid-flight
+   * (or a stale static VAULT_TOKEN) left every KV op failing permanently
+   * even with valid AppRole credentials in the env (issue #38).
+   */
+  private async withAppRoleFallback<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (error) {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+      const canFallback =
+        (status === 401 || status === 403) && !!this.roleId && !!this.secretId;
+      if (!canFallback) {
+        throw error;
+      }
+      this.logger.warn(
+        `Vault returned ${status}; attempting AppRole re-login and retry`,
+      );
+      const loginResult = await this.login();
+      if (loginResult.isFailure) {
+        throw error;
+      }
+      return await op();
+    }
+  }
 
   private async renewToken(): Promise<Result<void, VaultError>> {
     try {

--- a/src/modules/vault/infrastructure/adapters/vault-http.adapter.ts
+++ b/src/modules/vault/infrastructure/adapters/vault-http.adapter.ts
@@ -13,6 +13,12 @@ import { AsyncContextService } from 'src/common/context/async-context.service';
 import { Result } from 'src/common/types/result.type';
 
 /**
+ * Window applied to non-expiring Vault tokens (lookup-self ttl=0), so the
+ * token-expiry check in getToken() does not treat them as already expired.
+ */
+const NON_EXPIRING_TOKEN_WINDOW_MS = 10 * 365 * 24 * 60 * 60 * 1000; // ~10y
+
+/**
  * HTTP adapter for Vault client using axios.
  * Implements IVaultClient port with Result pattern error handling.
  * Handles token lifecycle (login, renew, unwrap wrapped tokens).
@@ -90,23 +96,41 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
       const data = resp.data?.data ?? {};
       const ttlSec = data.ttl ?? 0;
       this.token = this.vaultToken;
-      this.tokenExpire = new Date(Date.now() + ttlSec * 1000);
+      // ttl=0 means a non-expiring token (root/periodic). Treat it as
+      // far-future rather than "already expired".
+      this.tokenExpire =
+        ttlSec > 0
+          ? new Date(Date.now() + ttlSec * 1000)
+          : new Date(Date.now() + NON_EXPIRING_TOKEN_WINDOW_MS);
       this.isRenewable = !!data.renewable;
       this.httpClient.defaults.headers.common['X-Vault-Token'] =
         this.vaultToken;
       this.logger.log(
-        `Using pre-configured Vault token (ttl=${ttlSec}s renewable=${this.isRenewable})`,
+        `Using pre-configured Vault token (ttl=${ttlSec > 0 ? `${ttlSec}s` : 'non-expiring'} renewable=${this.isRenewable})`,
       );
-    } catch {
-      // Token inválido/expirado: descartarlo para que getToken() haga
-      // login() vía AppRole en la primera operación.
+    } catch (error: unknown) {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+      if (status === 401 || status === 403) {
+        // Token genuinely invalid/expired: discard it so getToken() falls
+        // back to AppRole login on the first operation.
+        this.logger.warn(
+          `Pre-configured VAULT_TOKEN rejected by Vault (${status}); falling back to AppRole`,
+        );
+        this.vaultToken = undefined;
+        this.token = null;
+        this.tokenExpire = null;
+        delete this.httpClient.defaults.headers.common['X-Vault-Token'];
+        return;
+      }
+      // Transient failure (network error, Vault down, timeout): keep the
+      // provisional token set in the constructor. withAppRoleFallback still
+      // recovers later if the token turns out to be invalid.
+      const reason = error instanceof Error ? error.message : String(error);
       this.logger.warn(
-        'Pre-configured VAULT_TOKEN invalid or expired; falling back to AppRole',
+        `lookup-self failed transiently (${reason}); keeping pre-configured token provisionally`,
       );
-      this.vaultToken = undefined;
-      this.token = null;
-      this.tokenExpire = null;
-      delete this.httpClient.defaults.headers.common['X-Vault-Token'];
     }
   }
 
@@ -167,13 +191,15 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
 
   async readKV(path: string): Promise<Result<VaultKVData, VaultError>> {
     try {
+      const safePath = this.assertSafeKvPath(path);
+
       const tokenResult = await this.getToken();
       if (tokenResult.isFailure) {
         this.emitEvent('read', path, 'failed', tokenResult.getError());
         return Result.fail(tokenResult.getError());
       }
 
-      const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${path}`;
+      const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${safePath}`;
       const response = await this.withAppRoleFallback(() =>
         this.httpClient.get<VaultKVData>(fullPath),
       );
@@ -193,13 +219,15 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
     data: Record<string, any>,
   ): Promise<Result<VaultKVData, VaultError>> {
     try {
+      const safePath = this.assertSafeKvPath(path);
+
       const tokenResult = await this.getToken();
       if (tokenResult.isFailure) {
         this.emitEvent('write', path, 'failed', tokenResult.getError());
         return Result.fail(tokenResult.getError());
       }
 
-      const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${path}`;
+      const fullPath = `/v1/${this.kvMount}/data/${this.vaultNamespace}/${safePath}`;
       const response = await this.withAppRoleFallback(() =>
         this.httpClient.post<VaultKVData>(fullPath, { data }),
       );
@@ -217,13 +245,15 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
 
   async deleteKV(path: string): Promise<Result<void, VaultError>> {
     try {
+      const safePath = this.assertSafeKvPath(path);
+
       const tokenResult = await this.getToken();
       if (tokenResult.isFailure) {
         this.emitEvent('delete', path, 'failed', tokenResult.getError());
         return Result.fail(tokenResult.getError());
       }
 
-      const fullPath = `/v1/${this.kvMount}/metadata/${this.vaultNamespace}/${path}`;
+      const fullPath = `/v1/${this.kvMount}/metadata/${this.vaultNamespace}/${safePath}`;
       await this.withAppRoleFallback(() => this.httpClient.delete(fullPath));
 
       this.logger.log(`Deleted secret from Vault: ${path}`);
@@ -272,6 +302,31 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
    */
 
   /**
+   * Validates a KV path before it is interpolated into a Vault URL.
+   * Rejects anything outside a strict allowlist (letters, digits, `.`, `-`,
+   * `_`, `/`) and any `..` segment, so a caller-supplied path cannot escape
+   * the configured mount/namespace and redirect the request elsewhere
+   * (server-side request forgery). Returns the validated path unchanged.
+   */
+  private assertSafeKvPath(path: string): string {
+    const SAFE_KV_PATH = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+    if (
+      typeof path !== 'string' ||
+      path.length === 0 ||
+      path.length > 256 ||
+      path.includes('..') ||
+      !SAFE_KV_PATH.test(path)
+    ) {
+      throw new VaultError(
+        400,
+        'Invalid Vault path',
+        `Vault path rejected (unsafe characters or traversal): ${path}`,
+      );
+    }
+    return path;
+  }
+
+  /**
    * Runs a Vault HTTP operation; if it fails with 401/403 and AppRole
    * credentials are configured, re-authenticates via AppRole and retries
    * the operation once. Without this, a token that expires mid-flight
@@ -285,9 +340,11 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
       const status = axios.isAxiosError(error)
         ? error.response?.status
         : undefined;
-      const canFallback =
-        (status === 401 || status === 403) && !!this.roleId && !!this.secretId;
-      if (!canFallback) {
+      // AppRole is usable when a role_id plus either a plain secret_id or a
+      // wrapped secret_id (unwrapped lazily by login()) is configured.
+      const hasAppRole =
+        !!this.roleId && (!!this.secretId || !!this.secretIdWrapped);
+      if ((status !== 401 && status !== 403) || !hasAppRole) {
         throw error;
       }
       this.logger.warn(
@@ -295,7 +352,11 @@ export class VaultHttpAdapter implements IVaultClient, OnModuleInit {
       );
       const loginResult = await this.login();
       if (loginResult.isFailure) {
-        throw error;
+        const loginError = loginResult.getError();
+        this.logger.error(
+          `AppRole re-login failed after ${status}: ${loginError.message}`,
+        );
+        throw loginError;
       }
       return await op();
     }


### PR DESCRIPTION
## Summary

Dos bugs encadenados hacían que el `VAULT_TOKEN` estático fuera de facto obligatorio y no autorrecuperable — al expirar dejaba `api-classical` en crash-loop pese a tener credenciales AppRole válidas.

- **Bug 1 — schema:** `VAULT_TOKEN` estaba `required()`. Un deployment AppRole-only moría en el bootstrap (`"VAULT_TOKEN" is not allowed to be empty`). Ahora `VAULT_TOKEN`, `VAULT_ROLE_ID` y `VAULT_SECRET_ID` son opcionales, con una regla `.custom()` que exige **al menos uno**: token estático (legacy) o el par AppRole completo (recomendado).
- **Bug 2a — TTL a ciegas:** el adapter asumía 24h de TTL para cualquier `VAULT_TOKEN` sin verificar, y lo marcaba no-renovable. `onModuleInit` ahora hace `auth/token/lookup-self` para descubrir TTL y `renewable` reales; si el token es inválido lo descarta para que `getToken()` caiga a AppRole.
- **Bug 2b — sin fallback:** las ops KV que fallaban con 401/403 fallaban para siempre. Nuevo `withAppRoleFallback`: ante 401/403 con AppRole configurado, re-login vía AppRole y reintento único. `readKV`/`writeKV`/`deleteKV` quedan envueltas.
- **.env.example:** documenta la convención — preferir AppRole, dejar `VAULT_TOKEN` vacío en producción.

## Test plan

- [x] `config.schema.spec.ts` — 4 tests: acepta AppRole solo, acepta token solo, rechaza si falta todo, rechaza AppRole incompleto.
- [x] `vault-http.adapter.spec.ts` — 3 tests: token estático expirado → login AppRole; `writeKV` 403 → re-login + retry; sin AppRole → no reintenta.
- [x] `yarn build` clean.
- [x] `yarn test` — 239 passing, sin regresiones.
- [ ] Validación en stack real (Portainer `23`): desplegar sin `VAULT_TOKEN`, confirmar boot OK vía AppRole.

## Fuera de scope (follow-ups sugeridos en el issue)

- Renombrar `VAULT_NAMESPACE` → `VAULT_KV_PATH_PREFIX`: es un rename de env var que toca configs de deployment (`vps-production-configs`). Mejor en un PR aparte coordinado con ops.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)