### PR TITLE
fix(permissions): stop caching empty permission resolutions (#42)

### DIFF
--- a/src/modules/permissions/application/permissions.service.spec.ts
+++ b/src/modules/permissions/application/permissions.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PermissionsService } from './permissions.service';
+import { CacheService } from 'src/common/cache/cache.service';
+import { RolesService } from '../../roles/application/roles.service';
+import { UsersService } from '../../users/application/users.service';
+import { Actor } from 'src/common/interfaces';
+
+/**
+ * Issue #21 / classical-server-app#42 — /modules/navigation devolvía
+ * intermitentemente data:[]. Causa: cuando la resolución de permisos daba
+ * vacío (p.ej. findActiveByKeys traga un error de Mongo y devuelve []), ese
+ * resultado vacío se CACHEABA ~60s, envenenando toda la sesión.
+ *
+ * Fix: no cachear resoluciones de permisos vacías, para que la siguiente
+ * petición recompute en lugar de servir un vacío pegado.
+ */
+describe('PermissionsService caching', () => {
+    let service: PermissionsService;
+    let cacheService: { getByKey: jest.Mock; set: jest.Mock };
+    let rolesService: { findActiveByKeys: jest.Mock };
+    let usersService: { findByIdRaw: jest.Mock };
+
+    const actor: Actor = { actorType: 'user', actorId: 'u1' } as Actor;
+
+    beforeEach(async () => {
+        cacheService = { getByKey: jest.fn().mockResolvedValue(null), set: jest.fn().mockResolvedValue(undefined) };
+        rolesService = { findActiveByKeys: jest.fn() };
+        usersService = {
+            findByIdRaw: jest.fn().mockResolvedValue({ roleKey: 'user', additionalRoleKeys: ['merchant'] }),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PermissionsService,
+                { provide: CacheService, useValue: cacheService },
+                { provide: RolesService, useValue: rolesService },
+                { provide: UsersService, useValue: usersService },
+            ],
+        }).compile();
+
+        service = module.get(PermissionsService);
+    });
+
+    it('no cachea cuando los permisos resueltos están vacíos', async () => {
+        // findActiveByKeys devuelve [] (p.ej. error de DB tragado) → permisos vacíos
+        rolesService.findActiveByKeys.mockResolvedValue([]);
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(result.exactPermissions.size).toBe(0);
+        expect(cacheService.set).not.toHaveBeenCalled();
+    });
+
+    it('cachea cuando los permisos resueltos NO están vacíos', async () => {
+        rolesService.findActiveByKeys.mockResolvedValue([
+            { permissionKeys: ['transactions.read', 'modules.*'] },
+        ]);
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(result.exactPermissions.has('transactions.read')).toBe(true);
+        expect(cacheService.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('devuelve el caché sin consultar la DB cuando existe', async () => {
+        cacheService.getByKey.mockResolvedValue({
+            permissions: {
+                hasGlobalWildcard: false,
+                moduleWildcards: [],
+                exactPermissions: ['transactions.read'],
+            },
+            cachedAt: 1,
+        });
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(result.exactPermissions.has('transactions.read')).toBe(true);
+        expect(rolesService.findActiveByKeys).not.toHaveBeenCalled();
+        expect(cacheService.set).not.toHaveBeenCalled();
+    });
+});

--- a/src/modules/permissions/application/permissions.service.spec.ts
+++ b/src/modules/permissions/application/permissions.service.spec.ts
@@ -70,13 +70,24 @@ describe('PermissionsService caching', () => {
                 moduleWildcards: [],
                 exactPermissions: ['transactions.read'],
             },
-            cachedAt: 1,
         });
 
         const result = await service.resolvePermissions(actor);
 
         expect(result.exactPermissions.has('transactions.read')).toBe(true);
         expect(rolesService.findActiveByKeys).not.toHaveBeenCalled();
+        expect(cacheService.set).not.toHaveBeenCalled();
+    });
+
+    it('cuando findActiveByKeys lanza, falla-cerrado (vacío) y NO cachea', async () => {
+        // Escenario real del bug #42: un error transitorio de Mongo se propaga.
+        rolesService.findActiveByKeys.mockRejectedValue(new Error('Mongo timeout'));
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(result.hasGlobalWildcard).toBe(false);
+        expect(result.moduleWildcards.size).toBe(0);
+        expect(result.exactPermissions.size).toBe(0);
         expect(cacheService.set).not.toHaveBeenCalled();
     });
 });

--- a/src/modules/permissions/application/permissions.service.ts
+++ b/src/modules/permissions/application/permissions.service.ts
@@ -16,7 +16,6 @@ interface PermissionsCacheEntry {
     moduleWildcards: Set<string>;
     exactPermissions: Set<string>;
   };
-  cachedAt: number;
 }
 
 /**

--- a/src/modules/permissions/application/permissions.service.ts
+++ b/src/modules/permissions/application/permissions.service.ts
@@ -69,10 +69,17 @@ export class PermissionsService {
 
     try {
       const permissions = await this.fetchPermissionsFromDB(actor);
-      await this.cacheService.set(cacheKey, {
-        permissions,
-        cachedAt: Date.now(),
-      });
+      // Issue #42: NO cachear resoluciones vacías. Un vacío puede provenir de
+      // un fallo transitorio (p.ej. findActiveByKeys traga un error de Mongo y
+      // devuelve []), y cachearlo envenenaría la sesión durante todo el TTL.
+      // Sólo cacheamos resoluciones con al menos un permiso; las vacías se
+      // recomputan en la siguiente petición.
+      if (!this.isEmptyPermissions(permissions)) {
+        await this.cacheService.set(cacheKey, {
+          permissions,
+          cachedAt: Date.now(),
+        });
+      }
       return permissions;
     } catch (error: any) {
       this.logger.error(
@@ -86,6 +93,22 @@ export class PermissionsService {
         exactPermissions: new Set<string>(),
       };
     }
+  }
+
+  /**
+   * Indica si una estructura de permisos no concede ningún acceso.
+   * Issue #42: se usa para evitar cachear resoluciones vacías.
+   */
+  private isEmptyPermissions(permissions: {
+    hasGlobalWildcard: boolean;
+    moduleWildcards: Set<string>;
+    exactPermissions: Set<string>;
+  }): boolean {
+    return (
+      !permissions.hasGlobalWildcard &&
+      permissions.moduleWildcards.size === 0 &&
+      permissions.exactPermissions.size === 0
+    );
   }
 
   /**

--- a/src/modules/roles/application/roles.service.spec.ts
+++ b/src/modules/roles/application/roles.service.spec.ts
@@ -636,3 +636,42 @@ describe.skip('RolesService', () => {
     });
   });
 });
+
+/**
+ * Issue #42 — findActiveByKeys tragaba cualquier error del repositorio y
+ * devolvía [], indistinguible de "sin roles activos". Eso hacía que un fallo
+ * transitorio de Mongo produjera permisos vacíos (que luego se cacheaban). El
+ * error debe propagarse para que el caller falle-cerrado por petición.
+ */
+describe('RolesService.findActiveByKeys error handling', () => {
+  let service: RolesService;
+  let rolesRepository: { findByKeysAndStatus: jest.Mock };
+
+  beforeEach(async () => {
+    rolesRepository = { findByKeysAndStatus: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesService,
+        { provide: RolesRepository, useValue: rolesRepository },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: AsyncContextService, useValue: { getRequestId: jest.fn().mockReturnValue('req') } },
+        { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<RolesService>(RolesService);
+  });
+
+  it('propaga el error del repositorio en lugar de devolver []', async () => {
+    rolesRepository.findByKeysAndStatus.mockRejectedValue(new Error('Mongo timeout'));
+
+    await expect(service.findActiveByKeys(['user', 'merchant'])).rejects.toThrow('Mongo timeout');
+  });
+
+  it('devuelve los roles activos cuando el repositorio responde', async () => {
+    rolesRepository.findByKeysAndStatus.mockResolvedValue([{ key: 'user' }]);
+
+    await expect(service.findActiveByKeys(['user'])).resolves.toEqual([{ key: 'user' }]);
+  });
+});

--- a/src/modules/roles/application/roles.service.ts
+++ b/src/modules/roles/application/roles.service.ts
@@ -1075,7 +1075,11 @@ export class RolesService {
         `Error al obtener roles activos por keys: ${(error as Error).message}`,
         (error as Error).stack,
       );
-      return [];
+      // Issue #42: NO devolver [] ante un error — eso es indistinguible de
+      // "sin roles activos" y hacía que un fallo transitorio de Mongo se
+      // tradujera en permisos vacíos (que luego se cacheaban). Propagamos para
+      // que PermissionsService falle-cerrado por petición sin envenenar caché.
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Problem

`GET /modules/navigation` intermittently returned `200` with `data: []` for the same authenticated merchant — two consecutive cold reloads returned 5 nav items then 0. This produced a blank admin sidebar (athendat/classical-admin-app#21).

## Root cause

A transient role-lookup failure produced an empty permission set that was then **cached for the full TTL (~60s)**. Every request in that window saw zero permissions, so the navigation builder filtered out every module. Two defects combined:

1. `RolesService.findActiveByKeys` wrapped the repository call in try/catch and **returned `[]` on any error**, making a DB timeout/blip indistinguishable from "no active roles".
2. `PermissionsService.resolvePermissions` **cached whatever came back — including an empty set** — so the transient empty stuck for the TTL.

## Fix

- `resolvePermissions` no longer caches an empty resolution (no global wildcard, no module wildcards, no exact permissions). Empty results are recomputed next request instead of poisoning the cache; genuine non-empty resolutions are still cached.
- `findActiveByKeys` propagates repository errors instead of returning `[]`, so a DB error fails-closed per request (via `resolvePermissions`' try/catch) without being cached.

## Tests

- `permissions.service.spec.ts` (new, 3): empty resolution not cached; non-empty cached; cache hit skips DB.
- `roles.service.spec.ts`: new `findActiveByKeys` suite (2) — propagates repo error; returns roles on success.
- Full suite: **247 passed, 0 failed**.

## Known follow-ups (not in this PR)
- `CacheService` never reads `REDIS_TTL` (hardcoded 60s) — `cache.service.ts:24-31`.
- `PermissionsService.invalidateCache` is defined but never called on role/permission mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)