### PR TITLE
feat: tenant-scoped user management for merchants

### DIFF
--- a/src/common/bootstrap/system-bootstrap.service.ts
+++ b/src/common/bootstrap/system-bootstrap.service.ts
@@ -116,15 +116,12 @@ export class SystemBootstrapService implements OnModuleInit {
     this.logger.log('👥 PHASE 2: Bootstrap roles...');
 
     try {
-      const count = await this.roleModel.countDocuments().exec();
-
-      if (count > 0) {
-        this.logger.log(
-          `   ⏭️  Roles collection already has ${count} documents - skipping seed`,
-        );
-        return;
-      }
-
+      // Reconciliación idempotente: NO hacemos early-return si ya existen roles.
+      // El loop hace upsert por `key` con `$set: {...role}`, de modo que los
+      // cambios de permisos de roles de sistema (definidos en código) se
+      // propagan a entornos existentes en cada arranque. Los roles custom (no
+      // presentes en SYSTEM_ROLES) no se tocan. Antes, el early-return dejaba
+      // los permisos desincronizados respecto del código (issue #42-adjacent).
       let seedCount = 0;
       for (const role of SYSTEM_ROLES) {
         try {

--- a/src/common/bootstrap/system-bootstrap.service.ts
+++ b/src/common/bootstrap/system-bootstrap.service.ts
@@ -125,14 +125,21 @@ export class SystemBootstrapService implements OnModuleInit {
       let seedCount = 0;
       for (const role of SYSTEM_ROLES) {
         try {
+          // Reconciliamos SÓLO los campos definidos por código que queremos
+          // mantener en sincronía (permisos + metadata de presentación). NO
+          // tocamos `status` en updates para no revertir un cambio out-of-band;
+          // se fija únicamente al insertar ($setOnInsert).
           await this.roleModel.updateOne(
             { key: role.key },
             {
               $set: {
-                ...role,
+                permissionKeys: role.permissionKeys,
+                name: role.name,
+                description: role.description,
                 isSystem: true,
               },
               $setOnInsert: {
+                status: role.status,
                 createdAt: new Date(),
               },
             },

--- a/src/middlewares/request-id.middleware.ts
+++ b/src/middlewares/request-id.middleware.ts
@@ -2,7 +2,7 @@ import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 
 import { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import * as jwt_decode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import { ClsService } from 'nestjs-cls';
 
 import { AppClsStore } from '../common/context/cls-store.interface';
@@ -47,7 +47,11 @@ export class RequestIdMiddleware implements NestMiddleware {
       }
 
       const token = authHeader.substring(7);
-      const decoded = (jwt_decode as any)(token);
+      // jwt-decode v4 exporta el named `jwtDecode` (no default). El código previo
+      // (`import * as jwt_decode` + llamarlo como función) rompía con
+      // "jwt_decode is not a function" tras el bump de dependencias, dejando el
+      // actor del contexto (cls) sin setear → resolución de permisos vacía → 403.
+      const decoded = jwtDecode<Record<string, any>>(token);
 
       return {
         actorId: decoded.actorId || 'unknown',

--- a/src/modules/permissions/application/permissions.service.spec.ts
+++ b/src/modules/permissions/application/permissions.service.spec.ts
@@ -79,6 +79,30 @@ describe('PermissionsService caching', () => {
         expect(cacheService.set).not.toHaveBeenCalled();
     });
 
+    it('devuelve los permisos computados aunque cacheService.set falle (caché no debe denegar)', async () => {
+        rolesService.findActiveByKeys.mockResolvedValue([
+            { permissionKeys: ['users.view'] },
+        ]);
+        cacheService.set.mockRejectedValue(new Error('Redis write down'));
+
+        const result = await service.resolvePermissions(actor);
+
+        // Un fallo de ESCRITURA de caché no debe denegar: devolvemos lo computado.
+        expect(result.exactPermissions.has('users.view')).toBe(true);
+    });
+
+    it('recomputa desde la DB cuando cacheService.getByKey falla (caché no debe denegar)', async () => {
+        cacheService.getByKey.mockRejectedValue(new Error('Redis read down'));
+        rolesService.findActiveByKeys.mockResolvedValue([
+            { permissionKeys: ['users.view'] },
+        ]);
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(rolesService.findActiveByKeys).toHaveBeenCalled();
+        expect(result.exactPermissions.has('users.view')).toBe(true);
+    });
+
     it('cuando findActiveByKeys lanza, falla-cerrado (vacío) y NO cachea', async () => {
         // Escenario real del bug #42: un error transitorio de Mongo se propaga.
         rolesService.findActiveByKeys.mockRejectedValue(new Error('Mongo timeout'));

--- a/src/modules/permissions/application/permissions.service.spec.ts
+++ b/src/modules/permissions/application/permissions.service.spec.ts
@@ -79,6 +79,24 @@ describe('PermissionsService caching', () => {
         expect(cacheService.set).not.toHaveBeenCalled();
     });
 
+    it('cachea los permisos como ARRAYS serializables, no como Set (round-trip JSON)', async () => {
+        // Bug raíz #42: un Set serializa a {} con JSON.stringify, así que al
+        // releer la caché los permisos quedaban vacíos → 403 intermitente.
+        rolesService.findActiveByKeys.mockResolvedValue([
+            { permissionKeys: ['users.view', 'transactions.*', '*'] },
+        ]);
+
+        await service.resolvePermissions(actor);
+
+        const cachedValue = cacheService.set.mock.calls[0][1] as any;
+        expect(Array.isArray(cachedValue.permissions.exactPermissions)).toBe(true);
+        expect(Array.isArray(cachedValue.permissions.moduleWildcards)).toBe(true);
+        expect(cachedValue.permissions.exactPermissions).toContain('users.view');
+        // Sobrevive un round-trip JSON (lo que hace CacheService.set):
+        const roundTripped = JSON.parse(JSON.stringify(cachedValue));
+        expect(roundTripped.permissions.exactPermissions).toContain('users.view');
+    });
+
     it('devuelve los permisos computados aunque cacheService.set falle (caché no debe denegar)', async () => {
         rolesService.findActiveByKeys.mockResolvedValue([
             { permissionKeys: ['users.view'] },

--- a/src/modules/permissions/application/permissions.service.spec.ts
+++ b/src/modules/permissions/application/permissions.service.spec.ts
@@ -121,6 +121,21 @@ describe('PermissionsService caching', () => {
         expect(result.exactPermissions.has('users.view')).toBe(true);
     });
 
+    it('recomputa desde la DB cuando la entrada de caché reconstruye vacía (legacy Set->{})', async () => {
+        // Entrada legacy escrita por el bug del Set: serializada como {}.
+        cacheService.getByKey.mockResolvedValue({
+            permissions: { hasGlobalWildcard: false, moduleWildcards: {}, exactPermissions: {} },
+        });
+        rolesService.findActiveByKeys.mockResolvedValue([
+            { permissionKeys: ['users.view'] },
+        ]);
+
+        const result = await service.resolvePermissions(actor);
+
+        expect(rolesService.findActiveByKeys).toHaveBeenCalled();
+        expect(result.exactPermissions.has('users.view')).toBe(true);
+    });
+
     it('cuando findActiveByKeys lanza, falla-cerrado (vacío) y NO cachea', async () => {
         // Escenario real del bug #42: un error transitorio de Mongo se propaga.
         rolesService.findActiveByKeys.mockRejectedValue(new Error('Mongo timeout'));

--- a/src/modules/permissions/application/permissions.service.ts
+++ b/src/modules/permissions/application/permissions.service.ts
@@ -45,53 +45,72 @@ export class PermissionsService {
   }> {
     const cacheKey = `permissions:${actor.actorType}:${actor.actorId}`;
 
-    // Intentar obtener del caché
-    const cached =
-      await this.cacheService.getByKey<PermissionsCacheEntry>(cacheKey);
-
-    if (cached) {
-      // Reconstruir Sets desde arrays (JSON.parse pierde tipos)
-      return {
-        hasGlobalWildcard: cached.permissions.hasGlobalWildcard,
-        moduleWildcards: new Set(
-          Array.isArray(cached.permissions.moduleWildcards)
-            ? cached.permissions.moduleWildcards
-            : Object.values(cached.permissions.moduleWildcards || {}),
-        ),
-        exactPermissions: new Set(
-          Array.isArray(cached.permissions.exactPermissions)
-            ? cached.permissions.exactPermissions
-            : Object.values(cached.permissions.exactPermissions || {}),
-        ),
-      };
+    // 1) Lectura de caché RESILIENTE: un fallo de Redis (lectura) NO debe
+    // denegar permisos — se trata como cache-miss y se recomputa desde la DB.
+    // (Antes esta llamada estaba fuera del try/catch, así que un error de Redis
+    // hacía 403 en TODAS las peticiones.)
+    try {
+      const cached =
+        await this.cacheService.getByKey<PermissionsCacheEntry>(cacheKey);
+      if (cached) {
+        // Reconstruir Sets desde arrays (JSON.parse pierde tipos)
+        return {
+          hasGlobalWildcard: cached.permissions.hasGlobalWildcard,
+          moduleWildcards: new Set(
+            Array.isArray(cached.permissions.moduleWildcards)
+              ? cached.permissions.moduleWildcards
+              : Object.values(cached.permissions.moduleWildcards || {}),
+          ),
+          exactPermissions: new Set(
+            Array.isArray(cached.permissions.exactPermissions)
+              ? cached.permissions.exactPermissions
+              : Object.values(cached.permissions.exactPermissions || {}),
+          ),
+        };
+      }
+    } catch (error: any) {
+      this.logger.warn(
+        `Permission cache read failed (degrading to DB) for ${actor.actorType}:${actor.actorId}: ${(error as Error).message}`,
+      );
     }
 
+    // 2) Resolver desde la DB. Sólo un fallo de la DB (no del caché) puede
+    // fallar-cerrado (deny).
+    let permissions: {
+      hasGlobalWildcard: boolean;
+      moduleWildcards: Set<string>;
+      exactPermissions: Set<string>;
+    };
     try {
-      const permissions = await this.fetchPermissionsFromDB(actor);
-      // Issue #42: NO cachear resoluciones vacías. Un vacío puede provenir de
-      // un fallo transitorio (p.ej. findActiveByKeys traga un error de Mongo y
-      // devuelve []), y cachearlo envenenaría la sesión durante todo el TTL.
-      // Sólo cacheamos resoluciones con al menos un permiso; las vacías se
-      // recomputan en la siguiente petición.
-      if (!this.isEmptyPermissions(permissions)) {
-        await this.cacheService.set(cacheKey, {
-          permissions,
-          cachedAt: Date.now(),
-        });
-      }
-      return permissions;
+      permissions = await this.fetchPermissionsFromDB(actor);
     } catch (error: any) {
       this.logger.error(
         `Failed to resolve permissions for ${actor.actorType}:${actor.actorId}: ${(error as Error).message}`,
         (error as Error).stack,
       );
-      // Fail-closed: deny por defecto
+      // Fail-closed: deny por defecto SÓLO ante fallo de resolución (DB).
       return {
         hasGlobalWildcard: false,
         moduleWildcards: new Set<string>(),
         exactPermissions: new Set<string>(),
       };
     }
+
+    // 3) Escritura de caché RESILIENTE: un fallo al cachear NO debe afectar el
+    // resultado (la caché es una optimización, no una fuente de verdad).
+    // Issue #42: además, NO cacheamos resoluciones vacías (evita envenenar la
+    // sesión si un vacío fue transitorio).
+    if (!this.isEmptyPermissions(permissions)) {
+      try {
+        await this.cacheService.set(cacheKey, { permissions });
+      } catch (error: any) {
+        this.logger.warn(
+          `Permission cache write failed (ignored) for ${actor.actorType}:${actor.actorId}: ${(error as Error).message}`,
+        );
+      }
+    }
+
+    return permissions;
   }
 
   /**

--- a/src/modules/permissions/application/permissions.service.ts
+++ b/src/modules/permissions/application/permissions.service.ts
@@ -54,19 +54,25 @@ export class PermissionsService {
         await this.cacheService.getByKey<PermissionsCacheEntry>(cacheKey);
       if (cached) {
         // Reconstruir Sets desde arrays (JSON.parse pierde tipos)
-        return {
+        const reconstructed = {
           hasGlobalWildcard: cached.permissions.hasGlobalWildcard,
-          moduleWildcards: new Set(
+          moduleWildcards: new Set<string>(
             Array.isArray(cached.permissions.moduleWildcards)
               ? cached.permissions.moduleWildcards
               : Object.values(cached.permissions.moduleWildcards || {}),
           ),
-          exactPermissions: new Set(
+          exactPermissions: new Set<string>(
             Array.isArray(cached.permissions.exactPermissions)
               ? cached.permissions.exactPermissions
               : Object.values(cached.permissions.exactPermissions || {}),
           ),
         };
+        // Defensivo: una entrada legacy escrita por el bug del Set (serializado
+        // como {}) reconstruye VACÍA. No la servimos (sería un 403 espurio hasta
+        // que expire el TTL): la tratamos como miss y recomputamos desde la DB.
+        if (!this.isEmptyPermissions(reconstructed)) {
+          return reconstructed;
+        }
       }
     } catch (error: any) {
       this.logger.warn(

--- a/src/modules/permissions/application/permissions.service.ts
+++ b/src/modules/permissions/application/permissions.service.ts
@@ -102,7 +102,19 @@ export class PermissionsService {
     // sesión si un vacío fue transitorio).
     if (!this.isEmptyPermissions(permissions)) {
       try {
-        await this.cacheService.set(cacheKey, { permissions });
+        // IMPORTANTE: serializar los Set como ARRAYS. CacheService.set hace
+        // JSON.stringify, y `JSON.stringify(new Set([...]))` === '{}' — es decir,
+        // un Set se persiste VACÍO y al releerlo los permisos quedaban en cero,
+        // produciendo 403 intermitentes (200 en el cache-miss que computa fresco,
+        // 403 durante el TTL leyendo el Set vacío). Guardamos arrays; la lectura
+        // ya los reconstruye con `new Set(array)`.
+        await this.cacheService.set(cacheKey, {
+          permissions: {
+            hasGlobalWildcard: permissions.hasGlobalWildcard,
+            moduleWildcards: Array.from(permissions.moduleWildcards),
+            exactPermissions: Array.from(permissions.exactPermissions),
+          },
+        });
       } catch (error: any) {
         this.logger.warn(
           `Permission cache write failed (ignored) for ${actor.actorType}:${actor.actorId}: ${(error as Error).message}`,

--- a/src/modules/roles/application/roles.service.spec.ts
+++ b/src/modules/roles/application/roles.service.spec.ts
@@ -675,3 +675,43 @@ describe('RolesService.findActiveByKeys error handling', () => {
     await expect(service.findActiveByKeys(['user'])).resolves.toEqual([{ key: 'user' }]);
   });
 });
+
+/**
+ * Roles asignables por un merchant a los usuarios de su tenant: sólo los roles
+ * de negocio (user, developer, merchant), nunca roles de plataforma
+ * (super_admin, admin, security_officer, ops, auditor).
+ */
+describe('RolesService.findTenantAssignable', () => {
+  let service: RolesService;
+  let rolesRepository: { findByKeysAndStatus: jest.Mock };
+
+  beforeEach(async () => {
+    rolesRepository = {
+      findByKeysAndStatus: jest
+        .fn()
+        .mockResolvedValue([{ key: 'user' }, { key: 'developer' }, { key: 'merchant' }]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesService,
+        { provide: RolesRepository, useValue: rolesRepository },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: AsyncContextService, useValue: { getRequestId: jest.fn().mockReturnValue('req') } },
+        { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<RolesService>(RolesService);
+  });
+
+  it('consulta SÓLO los roles de negocio (whitelist) y los devuelve', async () => {
+    const res = await service.findTenantAssignable();
+
+    expect(rolesRepository.findByKeysAndStatus).toHaveBeenCalledWith(
+      ['user', 'developer', 'merchant'],
+      RoleStatus.ACTIVE,
+    );
+    expect(res.data?.map((r) => r.key)).toEqual(['user', 'developer', 'merchant']);
+  });
+});

--- a/src/modules/roles/application/roles.service.ts
+++ b/src/modules/roles/application/roles.service.ts
@@ -15,6 +15,13 @@ import { AsyncContextService } from 'src/common/context/async-context.service';
 import { AuditService } from 'src/modules/audit/application/audit.service';
 
 /**
+ * Roles de negocio que un merchant puede asignar a los usuarios de su tenant.
+ * Excluye explícitamente los roles de plataforma (super_admin, admin,
+ * security_officer, ops, auditor).
+ */
+export const TENANT_ASSIGNABLE_ROLE_KEYS = ['user', 'developer', 'merchant'] as const;
+
+/**
  * RolesService - Servicio de aplicación para gestión de roles
  * Responsable de:
  * - CRUD de roles
@@ -1081,6 +1088,24 @@ export class RolesService {
       // que PermissionsService falle-cerrado por petición sin envenenar caché.
       throw error;
     }
+  }
+
+  /**
+   * Roles que un merchant puede asignar a los usuarios de su tenant.
+   *
+   * Sólo roles de negocio (user, developer, merchant) — NUNCA roles de
+   * plataforma (super_admin, admin, security_officer, ops, auditor). Se usa para
+   * poblar el formulario de alta de usuarios del tenant.
+   */
+  async findTenantAssignable(): Promise<ApiResponse<Role[]>> {
+    const requestId = this.asyncContextService.getRequestId();
+    const roles = await this.findActiveByKeys([...TENANT_ASSIGNABLE_ROLE_KEYS]);
+    return ApiResponse.ok<Role[]>(
+      HttpStatus.OK,
+      roles,
+      'Roles asignables obtenidos exitosamente',
+      { requestId },
+    );
   }
 
   /**

--- a/src/modules/roles/infrastructure/controllers/roles.controller.ts
+++ b/src/modules/roles/infrastructure/controllers/roles.controller.ts
@@ -144,6 +144,37 @@ export class RolesController {
   }
 
   /**
+   * Roles asignables por un merchant a los usuarios de su tenant.
+   * GET /roles/assignable
+   *
+   * Devuelve SÓLO los roles de negocio (user, developer, merchant), nunca roles
+   * de plataforma. Se gatea con `users.view` (que el merchant posee) en lugar de
+   * `roles.read`, para que un merchant pueda poblar el formulario de alta de
+   * usuarios sin acceso al catálogo global de roles. Declarado antes de /:id.
+   */
+  @Get('assignable')
+  @HttpCode(HttpStatus.OK)
+  @Permissions('users.view')
+  @ApiOperation({
+    summary: 'Roles asignables a usuarios del tenant',
+    description:
+      'Devuelve sólo los roles de negocio que un merchant puede asignar a los usuarios de su tenant.',
+  })
+  @ApiOkResponse({
+    description: 'Lista de roles asignables',
+    type: [Object],
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized',
+  })
+  async findTenantAssignable(@Res() res: Response): Promise<Response> {
+    const response: ApiResponse<Role[]> =
+      await this.rolesService.findTenantAssignable();
+
+    return res.status(response.statusCode).json(response);
+  }
+
+  /**
    * Obtener rol por clave única
    * GET /roles/by-key/:key
    */

--- a/src/modules/roles/seeds/system-roles.ts
+++ b/src/modules/roles/seeds/system-roles.ts
@@ -256,8 +256,9 @@ export const SYSTEM_ROLES = [
       // Gestión del comercio (propio)
       // `${MODULES.MERCHANTS}.view`,
 
-      // Usuarios del comercio
+      // Usuarios del comercio (gestión tenant-scoped de su propio tenant)
       `${MODULES.USERS}.view`,
+      `${MODULES.USERS}.create`,
 
       // Terminales del comercio
       `${MODULES.TERMINALS}.create`,

--- a/src/modules/users/application/users.service.tenant.spec.ts
+++ b/src/modules/users/application/users.service.tenant.spec.ts
@@ -85,6 +85,37 @@ describe('UsersService — tenant-scoped create', () => {
         expect(repoCreate).not.toHaveBeenCalled();
     });
 
+    it('RECHAZA (403) un roleKey fuera de la whitelist de negocio (anti escalada) y NO crea', async () => {
+        const escalation = { ...baseDto, roleKey: 'admin' } as unknown as CreateUserDto;
+
+        const res = await service.createTenantUser(escalation);
+
+        expect(res.statusCode).toBe(403);
+        expect(repoCreate).not.toHaveBeenCalled();
+    });
+
+    it('RECHAZA (403) additionalRoleKeys fuera de la whitelist (e.g. super_admin) y NO crea', async () => {
+        const escalation = {
+            ...baseDto,
+            roleKey: 'user',
+            additionalRoleKeys: ['super_admin'],
+        } as unknown as CreateUserDto;
+
+        const res = await service.createTenantUser(escalation);
+
+        expect(res.statusCode).toBe(403);
+        expect(repoCreate).not.toHaveBeenCalled();
+    });
+
+    it('permite un roleKey de negocio de la whitelist (developer)', async () => {
+        const dto = { ...baseDto, roleKey: 'developer' } as unknown as CreateUserDto;
+
+        const res = await service.createTenantUser(dto);
+
+        expect(res.statusCode).toBe(201);
+        expect(repoCreate).toHaveBeenCalledTimes(1);
+    });
+
     it('listTenantUsers filtra por el tenantId del contexto', async () => {
         await service.listTenantUsers({} as any);
 

--- a/src/modules/users/application/users.service.tenant.spec.ts
+++ b/src/modules/users/application/users.service.tenant.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { UsersService } from './users.service';
+import { UsersRepository } from '../infrastructure/adapters/users.repository';
+import { UserLifecycleRepository } from '../infrastructure/adapters/user-lifecycle.repository';
+import { AsyncContextService } from 'src/common/context/async-context.service';
+import { AuditService } from '../../audit/application/audit.service';
+import { CreateUserDto } from '../dto';
+
+/**
+ * Tenant-scoped user management (merchant gestiona usuarios de su propio tenant).
+ *
+ * Regla de aislamiento: el tenantId SIEMPRE se deriva del contexto del actor
+ * (JWT), NUNCA del payload del cliente. Un actor sin tenant no puede crear.
+ */
+describe('UsersService — tenant-scoped create', () => {
+    let service: UsersService;
+    let repoCreate: jest.Mock;
+    let repoFindAll: jest.Mock;
+    let getTenantId: jest.Mock;
+
+    const baseDto = {
+        email: 'cashier@shop.com',
+        fullname: 'Cashier One',
+        roleKey: 'user',
+        phone: '50912345',
+        idNumber: '12345678901',
+        password: 'P@ssw0rd2',
+    } as unknown as CreateUserDto;
+
+    beforeEach(async () => {
+        repoCreate = jest.fn().mockResolvedValue({
+            id: 'new-user-1',
+            email: baseDto.email,
+            fullname: baseDto.fullname,
+            roleKey: 'user',
+            status: 'active',
+        });
+        repoFindAll = jest.fn().mockResolvedValue({ data: [], total: 0, meta: {} });
+        getTenantId = jest.fn().mockReturnValue('tenant-1');
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                UsersService,
+                { provide: UsersRepository, useValue: { create: repoCreate, findAll: repoFindAll } },
+                { provide: UserLifecycleRepository, useValue: {} },
+                { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+                {
+                    provide: AsyncContextService,
+                    useValue: {
+                        getRequestId: jest.fn().mockReturnValue('req-1'),
+                        getActorId: jest.fn().mockReturnValue('merchant-1'),
+                        getTenantId,
+                    },
+                },
+                { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(UsersService);
+    });
+
+    it('asigna el tenantId del contexto al crear el usuario', async () => {
+        await service.createTenantUser(baseDto);
+
+        expect(repoCreate).toHaveBeenCalledTimes(1);
+        expect(repoCreate.mock.calls[0][0]).toMatchObject({ tenantId: 'tenant-1' });
+    });
+
+    it('IGNORA un tenantId enviado por el cliente (anti cross-tenant)', async () => {
+        const dtoWithEvilTenant = { ...baseDto, tenantId: 'tenant-EVIL' } as unknown as CreateUserDto;
+
+        await service.createTenantUser(dtoWithEvilTenant);
+
+        expect(repoCreate.mock.calls[0][0]).toMatchObject({ tenantId: 'tenant-1' });
+    });
+
+    it('falla-cerrado (403) y NO crea si el actor no tiene tenant', async () => {
+        getTenantId.mockReturnValue(undefined);
+
+        const res = await service.createTenantUser(baseDto);
+
+        expect(res.statusCode).toBe(403);
+        expect(repoCreate).not.toHaveBeenCalled();
+    });
+
+    it('listTenantUsers filtra por el tenantId del contexto', async () => {
+        await service.listTenantUsers({} as any);
+
+        expect(repoFindAll).toHaveBeenCalledTimes(1);
+        expect(repoFindAll.mock.calls[0][0]).toMatchObject({ tenantId: 'tenant-1' });
+    });
+
+    it('listTenantUsers falla-cerrado (403) y NO consulta si no hay tenant', async () => {
+        getTenantId.mockReturnValue(undefined);
+
+        const res = await service.listTenantUsers({} as any);
+
+        expect(res.statusCode).toBe(403);
+        expect(repoFindAll).not.toHaveBeenCalled();
+    });
+});

--- a/src/modules/users/application/users.service.ts
+++ b/src/modules/users/application/users.service.ts
@@ -31,6 +31,7 @@ import { buildMongoQuery } from 'src/common/helpers';
 import { UserStatus } from '../domain/enums/enums';
 import { isValidTransition } from '../domain/states-machines/user.state-machine';
 import type { Actor } from 'src/common/interfaces';
+import { TENANT_ASSIGNABLE_ROLE_KEYS } from '../../roles/application/roles.service';
 
 /**
  * Servicio de gestión de usuarios.
@@ -169,6 +170,27 @@ export class UsersService implements IUsersService {
         HttpStatus.FORBIDDEN,
         'NO_TENANT',
         'El usuario no pertenece a un tenant',
+        { requestId },
+      );
+    }
+
+    // Anti escalada de privilegios: un merchant SÓLO puede asignar roles de
+    // negocio (la whitelist tenant-asignable). El servidor enforce esto — no se
+    // confía en el cliente (el /roles/assignable es sólo para poblar la UI).
+    const allowedRoles = new Set<string>(TENANT_ASSIGNABLE_ROLE_KEYS);
+    const requestedRoles = [
+      dto.roleKey,
+      ...(dto.additionalRoleKeys ?? []),
+    ].filter(Boolean);
+    const invalidRoles = requestedRoles.filter((k) => !allowedRoles.has(k));
+    if (invalidRoles.length > 0) {
+      this.logger.warn(
+        `[${requestId}] createTenantUser intento de asignar rol(es) no permitido(s): ${invalidRoles.join(', ')}`,
+      );
+      return ApiResponse.fail<UserDTO>(
+        HttpStatus.FORBIDDEN,
+        'ROLE_NOT_ASSIGNABLE',
+        `No tienes permiso para asignar el/los rol(es): ${invalidRoles.join(', ')}`,
         { requestId },
       );
     }

--- a/src/modules/users/application/users.service.ts
+++ b/src/modules/users/application/users.service.ts
@@ -150,6 +150,105 @@ export class UsersService implements IUsersService {
   }
 
   /**
+   * Crear un usuario dentro del tenant del actor (merchant).
+   *
+   * Aislamiento de tenant: el `tenantId` se toma SIEMPRE del contexto del actor
+   * (derivado del JWT), nunca del payload del cliente — así un merchant no puede
+   * crear usuarios en otro tenant. Un actor sin tenant no puede crear (fail-closed).
+   */
+  async createTenantUser(dto: CreateUserDto): Promise<ApiResponse<UserDTO>> {
+    const requestId = this.asyncContextService.getRequestId();
+    const userId = this.asyncContextService.getActorId()!;
+    const tenantId = this.asyncContextService.getTenantId();
+
+    if (!tenantId) {
+      this.logger.warn(
+        `[${requestId}] createTenantUser sin tenant en el contexto del actor`,
+      );
+      return ApiResponse.fail<UserDTO>(
+        HttpStatus.FORBIDDEN,
+        'NO_TENANT',
+        'El usuario no pertenece a un tenant',
+        { requestId },
+      );
+    }
+
+    try {
+      this.logger.log(
+        `[${requestId}] Creating tenant user (tenant: ${tenantId}) with roleKey: ${dto.roleKey}`,
+      );
+
+      const passwordHash = await this.hashPassword(dto.password);
+
+      // `tenantId` después de `...dto` para que SIEMPRE gane el del contexto.
+      const user = await this.usersRepository.create({
+        ...dto,
+        userId,
+        tenantId,
+        passwordHash,
+      });
+
+      const userDto = this.mapToDTO(user);
+
+      this.auditService.logAllow('USER_CREATED', 'user', userId, {
+        module: 'users',
+        severity: 'HIGH',
+        tags: ['user', 'creation', 'tenant-scoped'],
+        changes: {
+          after: {
+            id: user.id,
+            email: user.email,
+            fullname: user.fullname,
+            roleKey: user.roleKey,
+            tenantId,
+            userId,
+          },
+        },
+      });
+
+      this.eventEmitter.emit(
+        'user.created',
+        new UserCreatedEvent(userId, userDto.email || userDto.id),
+      );
+
+      this.logger.log(
+        `[${requestId}] Tenant user created successfully: ${user.id}`,
+      );
+      return ApiResponse.ok<UserDTO>(
+        HttpStatus.CREATED,
+        userDto,
+        'Usuario creado exitosamente',
+        { requestId },
+      );
+    } catch (error: any) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `[${requestId}] Failed to create tenant user: ${errorMsg}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+
+      this.auditService.logError(
+        'USER_CREATE_FAILED',
+        'user',
+        userId,
+        error instanceof Error ? error : new Error(errorMsg),
+        {
+          module: 'users',
+          severity: 'HIGH',
+          tags: ['user', 'creation', 'tenant-scoped', 'error'],
+        },
+      );
+
+      return ApiResponse.fail<UserDTO>(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        errorMsg,
+        'Error interno al crear usuario',
+        { requestId },
+      );
+    }
+  }
+
+  /**
    * Obtener usuario por ID.
    *
    * Auditoría: registro de acceso con resultado (ALLOW/DENY)
@@ -384,6 +483,103 @@ export class UsersService implements IUsersService {
           module: 'users',
           severity: 'MEDIUM',
           tags: ['users', 'list', 'error'],
+        },
+      );
+
+      return ApiResponse.fail<UserDTO[]>(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        errorMsg,
+        'Error al listar usuarios',
+        { requestId },
+      );
+    }
+  }
+
+  /**
+   * Listar los usuarios del tenant del actor (merchant).
+   *
+   * Aislamiento de tenant: el filtro SIEMPRE incluye el `tenantId` del contexto
+   * del actor, por lo que sólo devuelve usuarios de su propio tenant. Un actor
+   * sin tenant no puede listar (fail-closed).
+   */
+  async listTenantUsers(
+    queryParams: QueryParams,
+  ): Promise<ApiResponse<UserDTO[]>> {
+    const requestId = this.asyncContextService.getRequestId();
+    const userId = this.asyncContextService.getActorId()!;
+    const tenantId = this.asyncContextService.getTenantId();
+
+    if (!tenantId) {
+      this.logger.warn(
+        `[${requestId}] listTenantUsers sin tenant en el contexto del actor`,
+      );
+      return ApiResponse.fail<UserDTO[]>(
+        HttpStatus.FORBIDDEN,
+        'NO_TENANT',
+        'El usuario no pertenece a un tenant',
+        { requestId },
+      );
+    }
+
+    try {
+      const searchFields = ['fullname', 'idNumber', 'email', 'phone'];
+      const { mongoFilter, options } = buildMongoQuery(
+        queryParams,
+        searchFields,
+      );
+
+      // Forzar el scope de tenant en el filtro (tras mongoFilter para que gane).
+      const filter = { ...mongoFilter, tenantId };
+
+      const { data: users, total, meta } = await this.usersRepository.findAll(
+        filter,
+        options,
+      );
+
+      const limit = options.limit;
+      const page = queryParams.page || 1;
+      const totalPages = Math.ceil(total / limit);
+      const skip = options.skip;
+      const hasMore = skip + limit < total;
+
+      const filteredUsers = users.filter((u) => u.roleKey !== 'super_admin');
+      const dtos = filteredUsers.map((u) => this.mapToDTO(u));
+
+      this.auditService.logAllow('USERS_LIST', 'users', userId, {
+        module: 'users',
+        severity: 'LOW',
+        tags: ['users', 'list', 'tenant-scoped'],
+        actorId: userId,
+        response: { count: dtos.length },
+      });
+
+      return ApiResponse.ok<UserDTO[]>(HttpStatus.OK, dtos, undefined, {
+        requestId,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages,
+          hasMore,
+        } as PaginationMeta,
+        ...meta,
+      });
+    } catch (error: any) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `[${requestId}] Failed to list tenant users: ${errorMsg}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+
+      this.auditService.logError(
+        'USERS_LIST_FAILED',
+        'users',
+        'tenant',
+        error instanceof Error ? error : new Error(errorMsg),
+        {
+          module: 'users',
+          severity: 'MEDIUM',
+          tags: ['users', 'list', 'tenant-scoped', 'error'],
         },
       );
 

--- a/src/modules/users/infrastructure/adapters/users.repository.ts
+++ b/src/modules/users/infrastructure/adapters/users.repository.ts
@@ -33,6 +33,7 @@ export class UsersRepository implements IUsersPort {
       idNumber: payload.idNumber,
       passwordHash: payload.passwordHash,
       metadata: payload.metadata,
+      tenantId: payload.tenantId,
       status: UserStatus.ACTIVE,
     });
 

--- a/src/modules/users/infrastructure/controllers/users.controller.ts
+++ b/src/modules/users/infrastructure/controllers/users.controller.ts
@@ -71,6 +71,69 @@ export class UsersController {
   ) { }
 
   /**
+   * Listar los usuarios del propio tenant (merchant).
+   * GET /users/my-tenant
+   *
+   * Tenant-scoped: el servicio filtra SIEMPRE por el tenantId del JWT, así que
+   * sólo devuelve usuarios del tenant del actor. Declarado antes de GET /:id
+   * para que la ruta literal no sea capturada por el parámetro.
+   */
+  @Get('my-tenant')
+  @Permissions('users.view')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Listar usuarios del propio tenant',
+    description:
+      'Devuelve los usuarios del tenant del actor (derivado del JWT). Scoped por tenant.',
+  })
+  async listMyTenantUsers(
+    @Res() res: Response,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('search') search?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortOrder') sortOrder?: SortOrder,
+    @Query('status') status?: string,
+    @Query('roleKey') roleKey?: string,
+  ): Promise<Response> {
+    const queryParams: QueryParams = {
+      page: page ? Number(page) : 1,
+      limit: limit ? Number(limit) : 10,
+      sortBy,
+      sortOrder,
+      search: search?.trim(),
+      filters: {
+        ...(status ? { status: status.trim() } : {}),
+        ...(roleKey ? { roleKey: roleKey.trim() } : {}),
+      },
+    };
+    const response = await this.usersService.listTenantUsers(queryParams);
+    return res.status(response.statusCode).json(response);
+  }
+
+  /**
+   * Crear un usuario en el propio tenant (merchant).
+   * POST /users/my-tenant
+   *
+   * Tenant-scoped: el tenantId se asigna desde el JWT (nunca desde el payload).
+   */
+  @Post('my-tenant')
+  @Permissions('users.create')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Crear usuario en el propio tenant',
+    description:
+      'Crea un usuario asignándole el tenantId del actor (derivado del JWT).',
+  })
+  async createMyTenantUser(
+    @Res() res: Response,
+    @Body() dto: CreateUserDto,
+  ): Promise<Response> {
+    const response = await this.usersService.createTenantUser(dto);
+    return res.status(response.statusCode).json(response);
+  }
+
+  /**
    * Crear nuevo usuario
    * POST /users
    *


### PR DESCRIPTION
Enables a **merchant** (tenant owner; JWT roleKey `user` + additionalRoleKeys `[merchant]` + tenantId) to list and create users within THEIR OWN tenant. Previously `/users` and `/roles` returned 403 for merchants, so a tenant owner couldn't manage their tenant's users at all.

## What's included
- **`UsersService.createTenantUser`** — derives `tenantId` from the actor context (JWT), never the client payload (anti cross-tenant); fail-closed 403 without a tenant.
- **`UsersService.listTenantUsers`** — lists users filtered by the actor's tenantId; fail-closed without a tenant.
- `UsersRepository.create` now persists `tenantId`.
- **`GET/POST /users/my-tenant`** (declared before `/users/:id`). GET requires `users.view`; POST requires `users.create`.
- **`GET /roles/assignable`** — returns ONLY business roles (`user`, `developer`, `merchant`); never platform roles. Gated with `users.view`.
- Seed: merchant role granted `users.create`. Bootstrap now **reconciles** system roles on every boot (idempotent upsert) instead of skipping when roles exist, so code-defined permission changes propagate to existing DBs.

## Bug fixes found while verifying (root causes of intermittent 403s)
- **Permission cache stored `Set`s** → `JSON.stringify(new Set())` === `'{}'` → permissions persisted empty → cache hits resolved to 0 permissions → intermittent 403. Now cached as arrays.
- **Cache failures denied permissions**: `getByKey` ran outside try/catch (read error → 403 everywhere); `set` error fell into the catch that returns empty. Made resolution resilient (cache errors degrade to DB, never deny).
- **jwt-decode v4**: `import * as jwt_decode` + calling it threw "jwt_decode is not a function" (named export `jwtDecode`); fixed.

## Tests
New: `users.service.tenant.spec.ts` (5), `roles.service` findActiveByKeys + findTenantAssignable suites, `permissions.service.spec.ts` (cache resilience + array serialization + don't-cache-empty). Full suite **257 passed**; build green. Verified live end-to-end (list, create, assignable roles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)