### PR TITLE
feat(transactions): from/to date-range filter on GET /transactions (#28)

### DIFF
--- a/src/modules/transactions/application/build-created-at-filter.spec.ts
+++ b/src/modules/transactions/application/build-created-at-filter.spec.ts
@@ -24,4 +24,15 @@ describe('buildCreatedAtRangeFilter (issue #28)', () => {
         expect(f.createdAt.$gte).toBeInstanceOf(Date);
         expect(f.createdAt.$lte).toBeUndefined();
     });
+
+    it('un `to` date-only (YYYY-MM-DD) cubre TODO el día (fin de día), no medianoche', () => {
+        const f = buildCreatedAtRangeFilter(undefined, '2026-06-02') as any;
+        // No debe ser medianoche UTC (excluiría el día entero).
+        expect(f.createdAt.$lte.toISOString()).toBe('2026-06-02T23:59:59.999Z');
+    });
+
+    it('un `from` date-only se ancla al inicio del día', () => {
+        const f = buildCreatedAtRangeFilter('2026-05-03', undefined) as any;
+        expect(f.createdAt.$gte.toISOString()).toBe('2026-05-03T00:00:00.000Z');
+    });
 });

--- a/src/modules/transactions/application/build-created-at-filter.spec.ts
+++ b/src/modules/transactions/application/build-created-at-filter.spec.ts
@@ -1,0 +1,27 @@
+import { buildCreatedAtRangeFilter } from './build-created-at-filter';
+
+describe('buildCreatedAtRangeFilter (issue #28)', () => {
+    it('arma $gte y $lte cuando vienen ambas fechas', () => {
+        const f = buildCreatedAtRangeFilter(
+            '2026-05-03T00:00:00.000Z',
+            '2026-06-02T23:59:59.999Z',
+        ) as any;
+        expect(f.createdAt.$gte).toBeInstanceOf(Date);
+        expect(f.createdAt.$lte).toBeInstanceOf(Date);
+        expect(f.createdAt.$gte.toISOString()).toBe('2026-05-03T00:00:00.000Z');
+    });
+
+    it('devuelve {} cuando no hay fechas', () => {
+        expect(buildCreatedAtRangeFilter()).toEqual({});
+    });
+
+    it('ignora fechas inválidas', () => {
+        expect(buildCreatedAtRangeFilter('no-es-fecha', undefined)).toEqual({});
+    });
+
+    it('acota sólo un extremo si sólo viene uno', () => {
+        const f = buildCreatedAtRangeFilter('2026-05-03T00:00:00.000Z') as any;
+        expect(f.createdAt.$gte).toBeInstanceOf(Date);
+        expect(f.createdAt.$lte).toBeUndefined();
+    });
+});

--- a/src/modules/transactions/application/build-created-at-filter.ts
+++ b/src/modules/transactions/application/build-created-at-filter.ts
@@ -1,3 +1,6 @@
+/** Detecta un string de fecha sin componente horario (YYYY-MM-DD). */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Construye el fragmento de filtro Mongo para acotar `createdAt` a un rango.
  *
@@ -5,6 +8,18 @@
  * la UI pero nunca lo aplicaba. El controller ahora recibe `from`/`to` (ISO) y
  * este helper los traduce a `{ createdAt: { $gte, $lte } }` para mezclarlo en el
  * filtro. Fechas ausentes o inválidas se ignoran (no acotan ese extremo).
+ *
+ * Diseño (review PR #45): se mantiene como helper PURO y aislado (en vez de
+ * enrutar `from`/`to` por el soporte `ranges` de buildMongoQuery) a propósito —
+ * es trivial de testear y NO cambia el comportamiento del path de rangos
+ * compartido para todos sus callers.
+ *
+ * Borde-de-día: un `to` date-only ("YYYY-MM-DD") se interpreta como FIN del día
+ * (23:59:59.999Z) para no excluir las transacciones de ese mismo día (sería un
+ * off-by-a-day); un `from` date-only ya ancla al inicio del día por defecto.
+ *
+ * Rango invertido (`from` > `to`): produce intencionalmente un conjunto vacío
+ * (Mongo evalúa $gte/$lte sin resultados) — no lo tratamos como error.
  */
 export function buildCreatedAtRangeFilter(
     from?: string,
@@ -19,6 +34,11 @@ export function buildCreatedAtRangeFilter(
 
     const toDate = to ? new Date(to) : undefined;
     if (toDate && !isNaN(toDate.getTime())) {
+        // Un `to` sin hora se parsea a medianoche UTC; lo empujamos a fin de día
+        // para incluir todas las transacciones de esa fecha.
+        if (DATE_ONLY.test(to!)) {
+            toDate.setUTCHours(23, 59, 59, 999);
+        }
         range['$lte'] = toDate;
     }
 

--- a/src/modules/transactions/application/build-created-at-filter.ts
+++ b/src/modules/transactions/application/build-created-at-filter.ts
@@ -1,0 +1,26 @@
+/**
+ * Construye el fragmento de filtro Mongo para acotar `createdAt` a un rango.
+ *
+ * Issue #28 (admin): el listado de transacciones mostraba el rango de fechas en
+ * la UI pero nunca lo aplicaba. El controller ahora recibe `from`/`to` (ISO) y
+ * este helper los traduce a `{ createdAt: { $gte, $lte } }` para mezclarlo en el
+ * filtro. Fechas ausentes o inválidas se ignoran (no acotan ese extremo).
+ */
+export function buildCreatedAtRangeFilter(
+    from?: string,
+    to?: string,
+): Record<string, unknown> {
+    const range: Record<string, Date> = {};
+
+    const fromDate = from ? new Date(from) : undefined;
+    if (fromDate && !isNaN(fromDate.getTime())) {
+        range['$gte'] = fromDate;
+    }
+
+    const toDate = to ? new Date(to) : undefined;
+    if (toDate && !isNaN(toDate.getTime())) {
+        range['$lte'] = toDate;
+    }
+
+    return Object.keys(range).length > 0 ? { createdAt: range } : {};
+}

--- a/src/modules/transactions/application/services/transaction-query.service.spec.ts
+++ b/src/modules/transactions/application/services/transaction-query.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TransactionQueryService } from './transaction-query.service';
+import { TransactionsRepository } from '../../infrastructure/adapters/transactions.repository';
+import { AsyncContextService } from 'src/common/context';
+import { AuditService } from 'src/modules/audit/application/audit.service';
+
+/**
+ * Issue #28 (review PR #45): el servicio debe MERGEAR el rango de fechas
+ * (createdAt) en el filtro Mongo que pasa al repositorio, componiéndolo con los
+ * demás filtros (e.g. status). Un test a nivel servicio evita regresiones si el
+ * spread del fragmento de fecha se cae.
+ */
+describe('TransactionQueryService.list — date range merge', () => {
+    let service: TransactionQueryService;
+    let findAll: jest.Mock;
+
+    beforeEach(async () => {
+        findAll = jest.fn().mockResolvedValue({ data: [], total: 0, meta: {} });
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                TransactionQueryService,
+                { provide: TransactionsRepository, useValue: { findAll } },
+                {
+                    provide: AsyncContextService,
+                    useValue: {
+                        getRequestId: jest.fn().mockReturnValue('req'),
+                        getActorId: jest.fn().mockReturnValue('actor-1'),
+                        getActor: jest.fn().mockReturnValue({ actorId: 'actor-1', actorType: 'user' }),
+                    },
+                },
+                { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(TransactionQueryService);
+    });
+
+    it('mezcla createdAt {$gte,$lte} y lo compone con el filtro de status', async () => {
+        await service.list(
+            { page: 1, limit: 5, filters: { status: 'success' } } as any,
+            undefined,
+            { from: '2026-05-03T00:00:00.000Z', to: '2026-06-02T23:59:59.999Z' },
+        );
+
+        expect(findAll).toHaveBeenCalledTimes(1);
+        const filterArg = findAll.mock.calls[0][0];
+        expect(filterArg.createdAt?.$gte).toBeInstanceOf(Date);
+        expect(filterArg.createdAt?.$lte).toBeInstanceOf(Date);
+        expect(filterArg.status).toBe('success');
+    });
+
+    it('no agrega createdAt cuando no hay rango', async () => {
+        await service.list({ page: 1, limit: 5, filters: {} } as any, undefined, {});
+
+        const filterArg = findAll.mock.calls[0][0];
+        expect(filterArg.createdAt).toBeUndefined();
+    });
+});

--- a/src/modules/transactions/application/services/transaction-query.service.ts
+++ b/src/modules/transactions/application/services/transaction-query.service.ts
@@ -9,6 +9,7 @@ import { AuditService } from 'src/modules/audit/application/audit.service';
 import { PaginationMeta, QueryParams } from 'src/common/types';
 import { Actor } from 'src/common/interfaces';
 import { buildMongoQuery } from 'src/common/helpers';
+import { buildCreatedAtRangeFilter } from '../build-created-at-filter';
 
 /**
  * Servicio de consulta para listar transacciones con filtrado inteligente
@@ -30,7 +31,11 @@ export class TransactionQueryService {
    * - merchant: filtrar por tenantId
    * - otros roles: permitir query params (tenantId, customerId, etc)
    */
-  async list(queryParams: QueryParams, contextApp?: string): Promise<ApiResponse<Transaction[]>> {
+  async list(
+    queryParams: QueryParams,
+    contextApp?: string,
+    dateRange?: { from?: string; to?: string },
+  ): Promise<ApiResponse<Transaction[]>> {
     const requestId = this.asyncContextService.getRequestId();
     const userId = this.asyncContextService.getActorId();
     const actor = this.asyncContextService.getActor()!;
@@ -51,10 +56,16 @@ export class TransactionQueryService {
       ];
 
       // Construir query de MongoDB
-      const { mongoFilter, options } = buildMongoQuery(
+      const { mongoFilter: baseFilter, options } = buildMongoQuery(
         queryParams,
         searchFields,
       );
+
+      // Issue #28: acotar por rango de fechas (createdAt) si vino from/to.
+      const mongoFilter = {
+        ...baseFilter,
+        ...buildCreatedAtRangeFilter(dateRange?.from, dateRange?.to),
+      };
 
       this.logger.log(
         `[${requestId}] MongoDB filter: ${JSON.stringify(mongoFilter)}`,

--- a/src/modules/transactions/infrastructure/adapters/transactions.repository.ts
+++ b/src/modules/transactions/infrastructure/adapters/transactions.repository.ts
@@ -207,8 +207,6 @@ export class TransactionsRepository implements ITransactionsRepository {
         filter.customerId = userId;
       }
 
-      console.log({ filter })
-
       // Ejecutar query en paralelo: obtener documentos y contar total
       const [transactions, total] = await Promise.all([
         this.transactionModel

--- a/src/modules/transactions/infrastructure/controllers/transactions.controller.ts
+++ b/src/modules/transactions/infrastructure/controllers/transactions.controller.ts
@@ -295,6 +295,8 @@ export class TransactionsController {
     @Query('sortBy') sortBy?: string,
     @Query('sortOrder') sortOrder?: SortOrder,
     @Query('status') status?: TransactionStatus,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
   ): Promise<Response> {
     // Construimos parámetros de consulta
     const queryParams: QueryParams = {
@@ -311,7 +313,8 @@ export class TransactionsController {
     // Obtener la app desde el header x-context-app para aplicar lógica de filtrado por rol
     const contextApp = req.header('x-context-app');
 
-    const response = await this.transactionQueryService.list(queryParams, contextApp);
+    // Issue #28: rango de fechas (createdAt) opcional.
+    const response = await this.transactionQueryService.list(queryParams, contextApp, { from, to });
     return res.status(response.statusCode).json(response);
   }
 

--- a/src/modules/transactions/infrastructure/controllers/transactions.controller.ts
+++ b/src/modules/transactions/infrastructure/controllers/transactions.controller.ts
@@ -276,6 +276,20 @@ export class TransactionsController {
     description: 'Filter by transaction status',
     example: 'new',
   })
+  @ApiQuery({
+    name: 'from',
+    required: false,
+    type: String,
+    description: 'Inicio del rango (ISO 8601) sobre createdAt',
+    example: '2026-05-03T00:00:00.000Z',
+  })
+  @ApiQuery({
+    name: 'to',
+    required: false,
+    type: String,
+    description: 'Fin del rango (ISO 8601) sobre createdAt',
+    example: '2026-06-02T23:59:59.999Z',
+  })
   @ApiOkResponse({
     description: 'Transactions recuperados',
     type: TransactionPaginatedResponseDto,


### PR DESCRIPTION
Adds optional `from`/`to` query params to `GET /transactions` so the admin's date-range filter is actually honored (createdAt range). Pure helper `buildCreatedAtRangeFilter` (ignores absent/invalid dates), merged into the Mongo filter by the query service. Tests (4) + build green.

Pairs with classical-admin-app PR (frontend sends from/to + fixes pagination). Fixes athendat/classical-admin-app#28 (backend half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)