### PR TITLE
fix(tenants): GET /tenants/my-tenant ya no devuelve 500 si el PAN del Vault falla (#46)

### DIFF
--- a/src/modules/tenants/application/tenant.service.spec.ts
+++ b/src/modules/tenants/application/tenant.service.spec.ts
@@ -1,0 +1,84 @@
+import { HttpStatus } from '@nestjs/common';
+
+import { TenantsService } from './tenant.service';
+import { Result } from '../../../common/types/result.type';
+
+/**
+ * Issue #46 — `GET /tenants/my-tenant` (getTenantByUser) devolvía 500
+ * ("Error al obtener tenant" / "Cannot get value from failed result") cuando el
+ * enriquecimiento con el PAN del Vault fallaba: el código llamaba
+ * `panResult.getValue()` sin verificar `isSuccess`, y getValue() lanza sobre un
+ * Result fallido. El PAN es un dato SUPLEMENTARIO — un fallo transitorio del
+ * Vault no debe tumbar la obtención del tenant. (Downstream: ese 500 hacía que
+ * el guard del admin botara al merchant a "Acceso Denegado" — admin #33.)
+ */
+describe('TenantsService.getTenantByUser', () => {
+    const tenantFixture = {
+        id: 'tenant-1',
+        code: '00000001',
+        businessName: 'ATHENDAT',
+        businessAddress: { address: 'Calle 23', city: 'La Habana', state: '', zipCode: '', country: 'CU' },
+        email: 'a@b.com',
+        status: 'active',
+        userId: 'user-1',
+    };
+
+    function buildService(getPanResult: Result<string>) {
+        const asyncContextService = {
+            getRequestId: () => 'req-1',
+            getActorId: () => 'user-1',
+            getActor: () => ({ id: 'user-1', roleKey: 'user' }),
+        };
+        const auditService = {
+            logAllow: jest.fn(),
+            logDeny: jest.fn(),
+            logError: jest.fn(),
+        };
+        const vaultService = {
+            getPan: jest.fn().mockResolvedValue(getPanResult),
+            maskPan: jest.fn((pan: string) => `**** ${pan.slice(-4)}`),
+        };
+        const tenantsRepository = {
+            findByUserId: jest.fn().mockResolvedValue(tenantFixture),
+        };
+
+        const service = new TenantsService(
+            asyncContextService as any,
+            auditService as any,
+            {} as any, // eventEmitter
+            {} as any, // lifecycleRepository
+            {} as any, // oauth2CredentialsService
+            {} as any, // tenantSequenceAdapter
+            tenantsRepository as any,
+            vaultService as any,
+            {} as any, // webhooksService
+            {} as any, // usersRepository
+        );
+        return { service, vaultService };
+    }
+
+    it('devuelve 200 con el tenant aunque el PAN del Vault falle (no 500)', async () => {
+        const { service } = buildService(Result.fail<string>(new Error('Vault sealed')));
+
+        const res = await service.getTenantByUser();
+
+        expect(res.ok).toBe(true);
+        expect(res.statusCode).toBe(HttpStatus.OK);
+        expect(res.data?.id).toBe('tenant-1');
+        // El PAN es suplementario: queda enmascarado/indefinido, no rompe la respuesta.
+        expect(res.data?.unmaskPan).toBeUndefined();
+        expect(res.data?.maskedPan).toBe('**** **** **** ****');
+    });
+
+    it('devuelve 200 con el PAN cuando el Vault responde', async () => {
+        const { service, vaultService } = buildService(Result.ok<string>('1234567812345678'));
+
+        const res = await service.getTenantByUser();
+
+        expect(res.ok).toBe(true);
+        expect(res.statusCode).toBe(HttpStatus.OK);
+        expect(res.data?.unmaskPan).toBe('1234567812345678');
+        expect(res.data?.maskedPan).toBe('**** 5678');
+        expect(vaultService.maskPan).toHaveBeenCalledWith('1234567812345678');
+    });
+});

--- a/src/modules/tenants/application/tenant.service.ts
+++ b/src/modules/tenants/application/tenant.service.ts
@@ -250,11 +250,15 @@ export class TenantsService {
         actorId: userId,
       });
 
-      // Enriquecer tenant con datos del Vault
+      // Enriquecer tenant con datos del Vault. Issue #46: guardar el Result del
+      // PAN (suplementario) en vez de getValue() a ciegas, que lanza sobre un
+      // Result fallido y provocaba un 500. Mismo idiom que el clientSecret debajo.
       const panResult = await this.vaultService.getPan(tenant.id);
 
-      const maskedPan = this.vaultService.maskPan(panResult.getValue());
-      const unmaskPan = panResult.getValue();
+      const maskedPan = panResult.isSuccess
+        ? this.vaultService.maskPan(panResult.getValue())
+        : '**** **** **** ****';
+      const unmaskPan = panResult.isSuccess ? panResult.getValue() : undefined;
 
       // Obtener clientSecret del Vault
       const clientSecretResult = await this.vaultService.getOAuth2ClientSecret(tenant.id);
@@ -344,11 +348,16 @@ export class TenantsService {
         actorId: userId,
       });
 
-      // Enriquecer tenant con datos del Vault
+      // Enriquecer tenant con datos del Vault. Issue #46: el PAN es suplementario
+      // — un fallo transitorio del Vault no debe tumbar la respuesta con un 500.
+      // Se guarda el Result (mismo idiom que el clientSecret) en vez de llamar
+      // getValue() a ciegas, que lanza sobre un Result fallido.
       const panResult = await this.vaultService.getPan(tenant.id);
 
-      const maskedPan = this.vaultService.maskPan(panResult.getValue());
-      const unmaskPan = panResult.getValue();
+      const maskedPan = panResult.isSuccess
+        ? this.vaultService.maskPan(panResult.getValue())
+        : '**** **** **** ****';
+      const unmaskPan = panResult.isSuccess ? panResult.getValue() : undefined;
 
       const responseDto = this.mapTenantToResponse(tenant, { maskedPan, unmaskPan });
 


### PR DESCRIPTION
Fixes #46

## Causa raíz

`getTenantByUser` (sirve `GET /tenants/my-tenant`) y `getTenantById` enriquecían el tenant con el PAN del Vault así:

```ts
const panResult = await this.vaultService.getPan(tenant.id);
const maskedPan = this.vaultService.maskPan(panResult.getValue()); // ⚠️ getValue() lanza
const unmaskPan = panResult.getValue();                            //    sobre un Result fallido
```

`Result.getValue()` **lanza `Error('Cannot get value from failed result')`** cuando el `Result` es un fallo. Así que un fallo **transitorio** del Vault (sellado/inalcanzable, o un tenant sin PAN) se convertía en un **500 "Error al obtener tenant"** — intermitente, justo lo reportado.

## Cambios

- El PAN es un dato **suplementario**: se guarda el `Result` con el **mismo idiom que el `clientSecret`** que ya estaba al lado (`result.isSuccess ? result.getValue() : <fallback>`). Si el Vault falla, se devuelve el tenant con `maskedPan='**** **** **** ****'` y `unmaskPan=undefined`, en vez de tumbar la respuesta con un 500.
- Aplicado en **ambos** métodos (`getTenantByUser` y `getTenantById`), que tenían el defecto idéntico.

## Impacto downstream

Ese 500 intermitente hacía que el guard de tenant del **admin** interpretara el error de servidor como denegación y botara al merchant a "Acceso Denegado" (admin #33, arreglado en su repo). Con este fix desaparece el disparador.

## Verificación

- Nuevo `tenant.service.spec.ts`: `getTenantByUser` devuelve **200 con el tenant aunque el PAN del Vault falle** (antes 500), y 200 con el PAN cuando el Vault responde.
- Suite del server **271 pass**; build verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
