### PR TITLE
fix(users): cierra escalada de privilegios en el endpoint global de creacion (#27)

### DIFF
--- a/src/modules/users/application/users.service.tenant.spec.ts
+++ b/src/modules/users/application/users.service.tenant.spec.ts
@@ -54,7 +54,7 @@ describe('UsersService — tenant-scoped create', () => {
                         getTenantId,
                     },
                 },
-                { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn() } },
+                { provide: AuditService, useValue: { logAllow: jest.fn(), logError: jest.fn(), logDeny: jest.fn() } },
             ],
         }).compile();
 
@@ -111,6 +111,30 @@ describe('UsersService — tenant-scoped create', () => {
         const dto = { ...baseDto, roleKey: 'developer' } as unknown as CreateUserDto;
 
         const res = await service.createTenantUser(dto);
+
+        expect(res.statusCode).toBe(201);
+        expect(repoCreate).toHaveBeenCalledTimes(1);
+    });
+
+    // Issue #27: el endpoint global POST /users (create) es administrativo de
+    // plataforma. Comparte el permiso `users.create` con el endpoint scoped
+    // /users/my-tenant, así que un merchant (tenant-bound, con users.create)
+    // podía alcanzarlo y crear un usuario con roleKey arbitrario (escalada) o en
+    // otro tenant. El create() global debe rechazar a actores tenant-bound.
+    it('#27: create() global RECHAZA (403) a un actor tenant-bound y NO crea', async () => {
+        // getTenantId por defecto = 'tenant-1' (actor ligado a tenant, p.ej. merchant)
+        const escalation = { ...baseDto, roleKey: 'admin' } as unknown as CreateUserDto;
+
+        const res = await service.create(escalation);
+
+        expect(res.statusCode).toBe(403);
+        expect(repoCreate).not.toHaveBeenCalled();
+    });
+
+    it('#27: create() global permite a un actor de plataforma (sin tenant)', async () => {
+        getTenantId.mockReturnValue(undefined);
+
+        const res = await service.create(baseDto);
 
         expect(res.statusCode).toBe(201);
         expect(repoCreate).toHaveBeenCalledTimes(1);

--- a/src/modules/users/application/users.service.ts
+++ b/src/modules/users/application/users.service.ts
@@ -73,6 +73,37 @@ export class UsersService implements IUsersService {
   async create(dto: CreateUserDto): Promise<ApiResponse<UserDTO>> {
     const requestId = this.asyncContextService.getRequestId();
     const userId = this.asyncContextService.getActorId()!;
+
+    // Issue #27 (SECURITY): este es el endpoint ADMINISTRATIVO de plataforma
+    // (POST /users), que crea con el roleKey/tenantId del payload sin scoping.
+    // Comparte el permiso `users.create` con el endpoint scoped /users/my-tenant,
+    // así que un actor ligado a un tenant (p.ej. merchant) podría alcanzarlo y
+    // escalar (roleKey arbitrario / tenant ajeno). Fail-closed: un actor con
+    // tenant DEBE usar createTenantUser (scoped, con whitelist de roles).
+    const tenantId = this.asyncContextService.getTenantId();
+    if (tenantId) {
+      this.logger.warn(
+        `[${requestId}] create() global bloqueado para actor tenant-bound (tenant: ${tenantId})`,
+      );
+      this.auditService.logDeny(
+        'USER_CREATE',
+        'user',
+        userId,
+        'Actor tenant-bound usando el endpoint global de creación de usuarios',
+        {
+          module: 'users',
+          severity: 'HIGH',
+          tags: ['user', 'creation', 'denied', 'security', 'tenant-isolation'],
+        },
+      );
+      return ApiResponse.fail<UserDTO>(
+        HttpStatus.FORBIDDEN,
+        'FORBIDDEN',
+        'Use el endpoint de su tenant para crear usuarios',
+        { requestId },
+      );
+    }
+
     try {
       this.logger.log(
         `[${requestId}] Creating user with roleKey: ${dto.roleKey}`,


### PR DESCRIPTION
Addresses #27 (privilege-escalation facet)

## Hallazgo

`POST /users` (endpoint administrativo de plataforma → `UsersService.create`) crea el usuario con el `roleKey`/`tenantId` del **payload**, sin scoping de tenant ni whitelist de roles. Comparte el permiso **`users.create`** con el endpoint scoped `/users/my-tenant` — que el rol **merchant** necesita legítimamente. Resultado: un merchant podía llamar el `POST /users` global con `roleKey:'admin'` y/o un `tenantId` ajeno → **escalada de privilegios + creación cross-tenant**.

## Fix

`create()` global ahora **falla-cerrado (403)** para cualquier actor ligado a un tenant (`getTenantId()` presente). Esos actores deben usar `createTenantUser` (`/users/my-tenant`), que ya fuerza el `tenantId` del JWT y aplica la whitelist `TENANT_ASSIGNABLE_ROLE_KEYS`. Los actores de plataforma (admin/super_admin, sin tenant en contexto) no se ven afectados.

## Estado de las demás facetas del #27 (mitigadas por seed posterior al reporte 2026-05-08)

- `GET /audit/logs` (8505 filas cross-tenant): el rol **merchant ya no tiene `audit.read`** → 403. Los audit events **no llevan `tenantId`** → el log es system-only (correctamente admin-only).
- `GET /users` global: exige **`users.edit`** (que el merchant no tiene) → 403.
- `GET /tenants`: pendiente de endurecer a admin-only como nota de seguimiento; hoy devuelve solo el tenant propio para el merchant.

## Verificación

- `users.service.tenant.spec.ts` +2 casos: actor tenant-bound → 403 sin crear; actor de plataforma → 201. Suite del módulo **10/10**; build verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
