### PR TITLE
fix(auth): Vault sellado al boot ya no crash-loopea el API (#40)

### DIFF
--- a/src/modules/auth/infrastructure/adapters/jwks.adapter.spec.ts
+++ b/src/modules/auth/infrastructure/adapters/jwks.adapter.spec.ts
@@ -1,0 +1,92 @@
+import { JwksAdapter } from './jwks.adapter';
+import { Result } from '../../../../common/types/result.type';
+
+/**
+ * Issue #40 — Vault sellado/inalcanzable al boot hacía que
+ * `JwksAdapter.onModuleInit` lanzara (re-throw), abortando el bootstrap de Nest;
+ * bajo `restart: unless-stopped` el contenedor crash-loopeaba y TODA la API
+ * (incl. /health) quedaba caída.
+ *
+ * Comportamiento esperado tras el fix:
+ *  - boot con Vault sellado ⇒ onModuleInit NO lanza (la API arranca).
+ *  - sin clave ⇒ firma falla-cerrada (no se mintan tokens sin clave real).
+ *  - cuando Vault vuelve ⇒ un reintento inicializa las claves (recupera sin restart).
+ *  - Vault accesible pero vacío (primer boot) ⇒ genera y persiste la clave default.
+ */
+describe('JwksAdapter — boot resilience (#40)', () => {
+    function buildAdapter(vaultClient: { readKV: jest.Mock; writeKV: jest.Mock }) {
+        const configService = {
+            get: jest.fn((key: string) => {
+                if (key === 'VAULT_KV_MOUNT') return 'secret';
+                if (key === 'JWKS_KEY_ROTATION_INTERVAL_HOURS') return 24;
+                return undefined;
+            }),
+        };
+        const eventEmitter = { emit: jest.fn() };
+        return new JwksAdapter(
+            vaultClient as any,
+            configService as any,
+            eventEmitter as any,
+        );
+    }
+
+    const sealed = () => ({
+        readKV: jest.fn().mockResolvedValue(Result.fail(new Error('Vault is sealed'))),
+        writeKV: jest.fn().mockResolvedValue(Result.fail(new Error('Vault is sealed'))),
+    });
+
+    const emptyReachable = () => ({
+        // readKV falla (no hay datos) pero writeKV funciona (Vault accesible).
+        readKV: jest.fn().mockResolvedValue(Result.fail(new Error('not found'))),
+        writeKV: jest.fn().mockResolvedValue(Result.ok(undefined)),
+    });
+
+    it('NO lanza en onModuleInit cuando Vault está sellado (la API arranca)', async () => {
+        const adapter = buildAdapter(sealed());
+
+        await expect(adapter.onModuleInit()).resolves.toBeUndefined();
+
+        adapter.onModuleDestroy();
+    });
+
+    it('falla-cerrado: sin clave activa, getActiveKey=null y getActivePrivateKey lanza', async () => {
+        const adapter = buildAdapter(sealed());
+        await adapter.onModuleInit();
+
+        await expect(adapter.getActiveKey()).resolves.toBeNull();
+        await expect(adapter.getActivePrivateKey()).rejects.toThrow();
+
+        adapter.onModuleDestroy();
+    });
+
+    it('Vault accesible pero vacío al boot: genera y activa la clave default', async () => {
+        const vault = emptyReachable();
+        const adapter = buildAdapter(vault);
+
+        await adapter.onModuleInit();
+
+        const active = await adapter.getActiveKey();
+        expect(active).not.toBeNull();
+        expect(vault.writeKV).toHaveBeenCalled();
+
+        adapter.onModuleDestroy();
+    });
+
+    it('recupera sin restart: tras boot sellado, un reintento con Vault accesible inicializa la clave', async () => {
+        const vault = sealed();
+        const adapter = buildAdapter(vault);
+        await adapter.onModuleInit();
+        expect(await adapter.getActiveKey()).toBeNull(); // notReady
+
+        // Vault se desella: readKV sigue sin datos, writeKV ahora funciona.
+        vault.readKV.mockResolvedValue(Result.fail(new Error('not found')));
+        vault.writeKV.mockResolvedValue(Result.ok(undefined));
+
+        const recovered = await (adapter as any).tryInitialize();
+
+        expect(recovered).toBe(true);
+        expect(await adapter.getActiveKey()).not.toBeNull();
+
+        adapter.onModuleDestroy();
+    });
+});

--- a/src/modules/auth/infrastructure/adapters/jwks.adapter.spec.ts
+++ b/src/modules/auth/infrastructure/adapters/jwks.adapter.spec.ts
@@ -89,4 +89,19 @@ describe('JwksAdapter — boot resilience (#40)', () => {
 
         adapter.onModuleDestroy();
     });
+
+    it('una vez inicializado, tryInitialize no regenera ni reescribe la clave', async () => {
+        const vault = emptyReachable();
+        const adapter = buildAdapter(vault);
+        await adapter.onModuleInit();
+        const writesAfterInit = vault.writeKV.mock.calls.length;
+
+        // Un reintento posterior (p.ej. tick rezagado) debe cortar de inmediato.
+        const again = await (adapter as any).tryInitialize();
+
+        expect(again).toBe(true);
+        expect(vault.writeKV.mock.calls.length).toBe(writesAfterInit);
+
+        adapter.onModuleDestroy();
+    });
 });

--- a/src/modules/auth/infrastructure/adapters/jwks.adapter.ts
+++ b/src/modules/auth/infrastructure/adapters/jwks.adapter.ts
@@ -35,6 +35,10 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
   private keysCache: Map<string, JwksKey> = new Map();
   private activeKidCache: string | null = null;
   private rotationTimer: NodeJS.Timeout | null = null;
+  /** Issue #40: estado de inicialización y reintento en background. */
+  private initialized = false;
+  private initRetryTimer: NodeJS.Timeout | null = null;
+  private readonly initRetryDelayMs = 10_000;
 
   constructor(
     @Inject(INJECTION_TOKENS.VAULT_CLIENT)
@@ -52,6 +56,29 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
 
   async onModuleInit(): Promise<void> {
     this.logger.log('Initializing JWKS adapter...');
+
+    const ok = await this.tryInitialize();
+    if (!ok) {
+      // Issue #40: NO lanzar. Un Vault sellado/inalcanzable no debe tumbar todo
+      // el API (incl. /health) ni provocar un crash-loop del contenedor. Se deja
+      // el adapter en estado `notReady` (la firma sigue fail-closed: getActiveKey
+      // devuelve null y getActivePrivateKey lanza) y se reintenta en background
+      // hasta que Vault esté accesible/desellado.
+      this.logger.warn(
+        `JWKS adapter not ready (Vault unavailable/sealed at boot). The API stays up; ` +
+          `token signing fails closed until Vault is reachable. Retrying every ${this.initRetryDelayMs}ms...`,
+      );
+      this.scheduleInitRetry();
+    }
+  }
+
+  /**
+   * Intenta cargar/generar las claves desde Vault. Issue #40: devuelve `false`
+   * (sin lanzar) si Vault está sellado/inalcanzable, dejando el estado interno
+   * limpio para que la firma quede fail-closed. Devuelve `true` cuando hay una
+   * clave activa lista.
+   */
+  private async tryInitialize(): Promise<boolean> {
     try {
       await this.loadKeysFromVault();
 
@@ -88,22 +115,61 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
       }
 
       // Programar rotación automática cada N horas
-      this.rotationTimer = setInterval(() => {
-        this.rotateKey().catch((err) => this.logger.error(err));
-      }, this.keyRotationIntervalMs);
+      if (!this.rotationTimer) {
+        this.rotationTimer = setInterval(() => {
+          this.rotateKey().catch((err) => this.logger.error(err));
+        }, this.keyRotationIntervalMs);
+      }
+      this.initialized = true;
       this.logger.log(
         `JWKS adapter initialized. Next rotation in ${this.keyRotationIntervalMs}ms`,
       );
+      return true;
     } catch (error: any) {
-      this.logger.error('Failed to initialize JWKS adapter', error);
-      // Fail-closed: si no podemos cargar claves, el servicio no arranca
-      throw error;
+      this.logger.error(
+        'Failed to initialize JWKS adapter (Vault unavailable?); will retry',
+        error,
+      );
+      // Fail-closed: descartar cualquier estado parcial en memoria para que la
+      // firma rechace operaciones hasta tener una clave realmente persistida.
+      this.keysCache.clear();
+      this.activeKidCache = null;
+      this.initialized = false;
+      return false;
     }
+  }
+
+  /**
+   * Issue #40: reintenta la inicialización en background hasta que Vault esté
+   * accesible/desellado, sin bloquear el arranque del API.
+   */
+  private scheduleInitRetry(): void {
+    if (this.initRetryTimer) return;
+    this.initRetryTimer = setInterval(() => {
+      void this.tryInitialize().then((ok) => {
+        if (ok) {
+          this.logger.log(
+            'JWKS adapter recovered: Vault reachable, keys initialized.',
+          );
+          if (this.initRetryTimer) {
+            clearInterval(this.initRetryTimer);
+            this.initRetryTimer = null;
+          }
+        }
+      });
+    }, this.initRetryDelayMs);
+    // No mantener vivo el event loop sólo por el reintento.
+    this.initRetryTimer.unref?.();
   }
 
   onModuleDestroy(): void {
     if (this.rotationTimer) {
       clearInterval(this.rotationTimer);
+      this.rotationTimer = null;
+    }
+    if (this.initRetryTimer) {
+      clearInterval(this.initRetryTimer);
+      this.initRetryTimer = null;
     }
   }
 

--- a/src/modules/auth/infrastructure/adapters/jwks.adapter.ts
+++ b/src/modules/auth/infrastructure/adapters/jwks.adapter.ts
@@ -37,6 +37,7 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
   private rotationTimer: NodeJS.Timeout | null = null;
   /** Issue #40: estado de inicialización y reintento en background. */
   private initialized = false;
+  private initInProgress = false;
   private initRetryTimer: NodeJS.Timeout | null = null;
   private readonly initRetryDelayMs = 10_000;
 
@@ -79,6 +80,14 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
    * clave activa lista.
    */
   private async tryInitialize(): Promise<boolean> {
+    // Ya hay una clave activa lista — nada que hacer (corta reintentos de más).
+    if (this.initialized) return true;
+    // Evita ejecuciones concurrentes: con `setInterval`, si un intento tarda más
+    // que el delay, el siguiente tick dispararía otro tryInitialize en paralelo
+    // y ambos generarían/persistirían la clave default en carrera.
+    if (this.initInProgress) return false;
+    this.initInProgress = true;
+
     try {
       await this.loadKeysFromVault();
 
@@ -136,6 +145,8 @@ export class JwksAdapter implements IJwksPort, OnModuleInit, OnModuleDestroy {
       this.activeKidCache = null;
       this.initialized = false;
       return false;
+    } finally {
+      this.initInProgress = false;
     }
   }
 


### PR DESCRIPTION
Fixes #40

## Problema

`JwksAdapter.onModuleInit` **re-lanzaba** cuando Vault estaba sellado/inalcanzable al boot (`generateNewKeyPair`/`saveKeysToVault` lanzan ante un 503 "Vault is sealed"), abortando el bootstrap de Nest. Bajo `restart: unless-stopped` el contenedor **crash-loopeaba** y **toda la API** (incluido el health-check) quedaba caída hasta el unseal manual — tumbó prod ~10 días.

## Fix (hardening — mantiene unseal manual)

- **`onModuleInit` ya NO lanza.** La lógica de carga/generación se extrae a `tryInitialize()`, que devuelve `false` (sin throw) si Vault no está disponible y **descarta cualquier estado parcial en memoria** (`keysCache`/`activeKidCache`) para que la firma quede **fail-closed**.
- Si no quedó lista, se programa un **reintento en background** (cada 10s, `unref`) que reinicializa en cuanto Vault esté accesible/desellado → **recupera sin restart**. El API arranca y el health-check queda verde.
- **Fail-closed en firma intacto:** `getActiveKey()` devuelve `null` y `getActivePrivateKey()` lanza mientras no haya una clave activa real — no se mintan tokens sin clave.
- **Vault accesible pero vacío** (primer boot / 404) conserva el comportamiento: genera y persiste la clave default.

## Verificación (TDD)

`jwks.adapter.spec.ts` (4 casos):
1. Vault sellado al boot → `onModuleInit` **no lanza**.
2. Sin clave → firma **fail-closed** (`getActiveKey`=null, `getActivePrivateKey` lanza).
3. Vault accesible pero vacío → genera y activa la clave default (persiste).
4. **Recuperación**: tras boot sellado, un reintento con Vault accesible inicializa la clave (sin restart).

Suite server **277 pass**; build verde.

## Scope

**No** agrega auto-unseal (decisión del mantenedor): solo hace que el API **tolere** la ventana sellada y auto-recupere al desellar, en vez de crash-loopear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
