### PR TITLE
fix(transactions): dispatch tenant webhook as single object, not array (#23)

### DIFF
--- a/src/modules/tenants/application/services/tenant-webhooks.service.ts
+++ b/src/modules/tenants/application/services/tenant-webhooks.service.ts
@@ -36,6 +36,7 @@ export class TenantWebhooksService {
       id: uuidv4(),
       url: null,
       events: [],
+      active: true,
       secret: uuidv4().replace(/-/g, ''),
     };
   }

--- a/src/modules/tenants/domain/models/webhook.ts
+++ b/src/modules/tenants/domain/models/webhook.ts
@@ -21,11 +21,13 @@
  * @property {string} id UUID único por webhook.
  * @property {string} url URL donde se enviarán los webhooks.
  * @property {string[]} events Eventos a los que suscribirse (ej.: 'transaction.created', 'transaction.confirmed').
+ * @property {boolean} active Si el webhook está activo y debe despacharse.
  * @property {string} secret Secret para firmar webhooks (HMAC-SHA256).
  */
 export class Webhook {
     id: string; // UUID único por webhook
     url?: string | null; // URL donde se enviarán los webhooks (opcional inicialmente, null por defecto)
     events: string[]; // Eventos a los que suscribirse (ej: 'transaction.created', 'transaction.confirmed')
+    active: boolean; // Si el webhook está activo y debe despacharse (el schema lo defaultea a true)
     secret: string; // Secret para firmar webhooks (HMAC-SHA256)
 }

--- a/src/modules/transactions/application/services/tenant-webhook.dispatcher.spec.ts
+++ b/src/modules/transactions/application/services/tenant-webhook.dispatcher.spec.ts
@@ -1,0 +1,103 @@
+import { Logger } from '@nestjs/common';
+
+import { TenantWebhookDispatcher } from './tenant-webhook.dispatcher';
+import { TransactionProcessedEvent } from '../../domain/events/transaction.events';
+import { Webhook } from 'src/modules/tenants/domain';
+
+/**
+ * Regression coverage for #23: the stored `tenant.webhook` is a single
+ * sub-document (object) or null — never an array. The dispatcher must read it
+ * as an object and actually POST when it is active + subscribed, instead of
+ * crashing with "tenant.webhook.filter is not a function".
+ */
+describe('TenantWebhookDispatcher', () => {
+  let dispatcher: TenantWebhookDispatcher;
+  let httpService: { post: jest.Mock };
+  let cryptoService: { createSignature: jest.Mock };
+  let tenantModel: { findOne: jest.Mock };
+
+  function mockTenant(webhook: Webhook | null) {
+    tenantModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(webhook ? { id: 'tenant-1', webhook } : { id: 'tenant-1', webhook: null }),
+    });
+  }
+
+  function activeWebhook(overrides: Partial<Webhook> = {}): Webhook {
+    return {
+      id: 'wh-1',
+      url: 'https://merchant.example.com/hook',
+      events: ['transaction.processed'],
+      active: true,
+      secret: 'shhh',
+      ...overrides,
+    };
+  }
+
+  const event = new TransactionProcessedEvent('tx-1', 'tenant-1', 'success');
+
+  beforeEach(() => {
+    httpService = { post: jest.fn().mockResolvedValue(undefined) };
+    cryptoService = { createSignature: jest.fn().mockReturnValue('sig') };
+    tenantModel = { findOne: jest.fn() };
+
+    dispatcher = new TenantWebhookDispatcher(
+      httpService as any,
+      cryptoService as any,
+      tenantModel as any,
+    );
+
+    // Keep test output pristine.
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('POSTs the webhook when the (single-object) webhook is active and subscribed', async () => {
+    mockTenant(activeWebhook());
+
+    await dispatcher.handleTransactionProcessed(event);
+
+    expect(httpService.post).toHaveBeenCalledTimes(1);
+    expect(httpService.post).toHaveBeenCalledWith(
+      'https://merchant.example.com/hook',
+      expect.objectContaining({ event: 'transaction.processed' }),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Webhook-Signature': 'sig' }),
+      }),
+    );
+  });
+
+  it('does not throw "filter is not a function" for the single-object shape', async () => {
+    mockTenant(activeWebhook());
+
+    await expect(dispatcher.handleTransactionProcessed(event)).resolves.toBeUndefined();
+    const errorCalls = (Logger.prototype.error as jest.Mock).mock.calls.flat().join(' ');
+    expect(errorCalls).not.toContain('is not a function');
+  });
+
+  it('does not POST when the tenant has no webhook configured', async () => {
+    mockTenant(null);
+
+    await dispatcher.handleTransactionProcessed(event);
+
+    expect(httpService.post).not.toHaveBeenCalled();
+  });
+
+  it('does not POST when the webhook is inactive', async () => {
+    mockTenant(activeWebhook({ active: false }));
+
+    await dispatcher.handleTransactionProcessed(event);
+
+    expect(httpService.post).not.toHaveBeenCalled();
+  });
+
+  it('does not POST when the webhook is not subscribed to the event', async () => {
+    mockTenant(activeWebhook({ events: ['transaction.created'] }));
+
+    await dispatcher.handleTransactionProcessed(event);
+
+    expect(httpService.post).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/transactions/application/services/tenant-webhook.dispatcher.ts
+++ b/src/modules/transactions/application/services/tenant-webhook.dispatcher.ts
@@ -15,6 +15,8 @@ import {
   TransactionCancelledEvent,
 } from '../../domain/events/transaction.events';
 import { Tenant } from 'src/modules/tenants/infrastructure/schemas/tenant.schema';
+import { Webhook } from 'src/modules/tenants/domain';
+import { isWebhookSubscribed } from './webhook-dispatch.helper';
 
 /**
  * Servicio que despacha webhook cuando ocurren eventos de transacción
@@ -117,7 +119,7 @@ export class TenantWebhookDispatcher {
   }
 
   /**
-   * Despacha webhook a todas las URLs configuradas para un evento específico
+   * Despacha el webhook configurado del tenant para un evento específico.
    * Fire-and-forget: no bloquea la operación original
    *
    * @param tenantId ID del tenant propietario de la transacción
@@ -130,33 +132,29 @@ export class TenantWebhookDispatcher {
     payload: Record<string, any>,
   ): Promise<void> {
     try {
-      // Obtener configuración de webhook del tenant
+      // Obtener configuración de webhook del tenant.
+      // El tenant guarda `webhook` como un sub-documento ÚNICO (o null), no un
+      // array — por eso se lee como objeto y se decide con un helper puro.
       const tenant = await this.tenantModel.findOne({ id: tenantId }).exec();
       if (!tenant || !tenant.webhook) {
         this.logger.log(`Ningún webhook configurado para tenant ${tenantId}`);
         return;
       }
 
-      // Filtrar webhook activos que están suscritos a este evento
-      const activeWebhook = (tenant.webhook as any).filter(
-        (webhook) => webhook.active && webhook.events.includes(eventType),
-      );
-
-      if (activeWebhook.length === 0) {
+      const webhook = tenant.webhook;
+      if (!isWebhookSubscribed(webhook, eventType)) {
         this.logger.log(
           `Ningún webhook activo para evento ${eventType} en tenant ${tenantId}`,
         );
         return;
       }
 
-      // Despachar a cada webhook
-      for (const webhook of activeWebhook) {
-        this.sendWebhook(webhook, eventType, payload).catch((error) => {
-          this.logger.error(
-            `Error enviando webhook a ${webhook.url}: ${error.message}`,
-          );
-        });
-      }
+      // Despachar el webhook configurado
+      await this.sendWebhook(webhook, eventType, payload).catch((error) => {
+        this.logger.error(
+          `Error enviando webhook a ${webhook.url}: ${error.message}`,
+        );
+      });
     } catch (error: any) {
       this.logger.error(`Error despachando webhook para tenant ${tenantId}: ${error.message}`);
     }
@@ -170,10 +168,18 @@ export class TenantWebhookDispatcher {
    * @param payload Datos a enviar
    */
   private async sendWebhook(
-    webhook: any,
+    webhook: Webhook,
     eventType: string,
     payload: Record<string, any>,
   ): Promise<void> {
+    // Invariante defensiva: `isWebhookSubscribed` ya garantiza una URL no vacía
+    // antes de llegar aquí; este guard sólo estrecha el tipo (url puede ser null).
+    const { url } = webhook;
+    if (!url) {
+      this.logger.warn(`Webhook ${webhook.id} sin URL configurada; se omite el envío`);
+      return;
+    }
+
     try {
       // Construir payload con metadatos
       const fullPayload = {
@@ -186,10 +192,10 @@ export class TenantWebhookDispatcher {
       const payloadString = JSON.stringify(fullPayload);
       const signature = this.cryptoService.createSignature(payloadString, webhook.secret);
 
-      this.logger.log(`Enviando webhook a ${webhook.url} con evento ${eventType}`);
+      this.logger.log(`Enviando webhook a ${url} con evento ${eventType}`);
 
       // Enviar POST con firma en header
-      await this.httpService.post(webhook.url, fullPayload, {
+      await this.httpService.post(url, fullPayload, {
         headers: {
           'X-Webhook-Signature': signature,
           'Content-Type': 'application/json',
@@ -197,10 +203,10 @@ export class TenantWebhookDispatcher {
         timeout: 10000, // 10 segundos timeout
       });
 
-      this.logger.log(`Webhook enviado exitosamente a ${webhook.url}`);
+      this.logger.log(`Webhook enviado exitosamente a ${url}`);
     } catch (error: any) {
       this.logger.error(
-        `Error enviando webhook a ${webhook.url}: ${error.message}`,
+        `Error enviando webhook a ${url}: ${error.message}`,
       );
       throw error;
     }

--- a/src/modules/transactions/application/services/webhook-dispatch.helper.spec.ts
+++ b/src/modules/transactions/application/services/webhook-dispatch.helper.spec.ts
@@ -1,0 +1,68 @@
+import { isWebhookSubscribed } from './webhook-dispatch.helper';
+import { Webhook } from 'src/modules/tenants/domain';
+
+/**
+ * Webhook activo y suscrito al evento, con URL configurada.
+ */
+function activeWebhook(overrides: Partial<Webhook> = {}): Webhook {
+  return {
+    id: 'wh-1',
+    url: 'https://merchant.example.com/hook',
+    events: ['transaction.processed', 'transaction.created'],
+    active: true,
+    secret: 'shhh',
+    ...overrides,
+  };
+}
+
+describe('isWebhookSubscribed', () => {
+  it('returns false when webhook is null', () => {
+    expect(isWebhookSubscribed(null, 'transaction.processed')).toBe(false);
+  });
+
+  it('returns false when webhook is undefined', () => {
+    expect(isWebhookSubscribed(undefined, 'transaction.processed')).toBe(false);
+  });
+
+  it('returns false when webhook is inactive', () => {
+    expect(
+      isWebhookSubscribed(activeWebhook({ active: false }), 'transaction.processed'),
+    ).toBe(false);
+  });
+
+  it('returns false when url is null (not yet configured)', () => {
+    expect(
+      isWebhookSubscribed(activeWebhook({ url: null }), 'transaction.processed'),
+    ).toBe(false);
+  });
+
+  it('returns false when url is an empty string', () => {
+    expect(
+      isWebhookSubscribed(activeWebhook({ url: '' }), 'transaction.processed'),
+    ).toBe(false);
+  });
+
+  it('returns false when not subscribed to the event', () => {
+    expect(
+      isWebhookSubscribed(activeWebhook({ events: ['transaction.created'] }), 'transaction.processed'),
+    ).toBe(false);
+  });
+
+  it('returns false when events is empty', () => {
+    expect(
+      isWebhookSubscribed(activeWebhook({ events: [] }), 'transaction.processed'),
+    ).toBe(false);
+  });
+
+  it('returns true when active, url configured, and subscribed to the event', () => {
+    expect(isWebhookSubscribed(activeWebhook(), 'transaction.processed')).toBe(true);
+  });
+
+  // Regression for #23: the stored shape is a single object, not an array.
+  // The helper must read it as an object and never throw "filter is not a function".
+  it('handles a single-object webhook (not an array) without throwing', () => {
+    const singleObject = activeWebhook();
+    expect(() => isWebhookSubscribed(singleObject, 'transaction.processed')).not.toThrow();
+    expect(isWebhookSubscribed(singleObject, 'transaction.processed')).toBe(true);
+  });
+});

--- a/src/modules/transactions/application/services/webhook-dispatch.helper.ts
+++ b/src/modules/transactions/application/services/webhook-dispatch.helper.ts
@@ -1,0 +1,21 @@
+import { Webhook } from 'src/modules/tenants/domain';
+
+/**
+ * Decide si un webhook (objeto único por tenant) debe despacharse para un
+ * evento dado. Defensa contra la forma del documento almacenado: `webhook` es
+ * un sub-documento único (o null), NO un array — por eso aquí se lee como
+ * objeto y nunca se llama `.filter`.
+ */
+export function isWebhookSubscribed(
+  webhook: Webhook | null | undefined,
+  eventType: string,
+): boolean {
+  return Boolean(
+    webhook &&
+      webhook.active === true &&
+      typeof webhook.url === 'string' &&
+      webhook.url.length > 0 &&
+      Array.isArray(webhook.events) &&
+      webhook.events.includes(eventType),
+  );
+}


### PR DESCRIPTION
## Problem

`TenantWebhookDispatcher` treated `tenant.webhook` as an **array** (`.filter()`, `for…of`), but the Tenant schema stores `webhook` as a **single sub-document** (or `null`). Every `transaction.*` event logged:

```
error: [TenantWebhookDispatcher] Error despachando webhook para tenant <id>: tenant.webhook.filter is not a function
```

Caught and downgraded to a log, so transactions still completed — but no outbound webhook was ever dispatched, and every request was noisy. Fixes #23.

## Root cause

The stored shape is canonically a single object: `Tenant.webhook` is `@Prop({ type: WebhookSchema })` (singular), `generateWebhook()` returns one object, and the whole `TenantWebhooksService` (`updateUrl`, `regenerateSecret`) reads `tenant.webhook.id`. Only the dispatcher drifted to array semantics, masked by an `as any` cast.

## Fix (TDD)

- **Pure helper** `isWebhookSubscribed(webhook, eventType)` — decides dispatch for the single-object shape (`active` + non-empty `url` + subscribed to event), never calls `.filter`. Spec-first (`webhook-dispatch.helper.spec.ts`, 9 tests).
- **Dispatcher** reads `tenant.webhook` as one object, drops the `as any`, and `sendWebhook` is typed to `Webhook` with a defensive `url` narrow. New `tenant-webhook.dispatcher.spec.ts` (5 tests) reproduces #23 (asserts the log never contains "is not a function") and covers POST-on-subscribed + no-webhook / inactive / not-subscribed no-ops.
- **Schema/model drift closed**: domain `Webhook` gains the `active` field (the Mongoose schema already had it). This is what surfaced a latent `webhook.url` (`string | null`) → `httpService.post(string)` type hole that the `any` cast had hidden. `generateWebhook()` now sets `active: true` (matches schema default).

## Acceptance criteria

- [x] Successful and failed transactions no longer produce `tenant.webhook.filter is not a function`.
- [x] A configured (active + url + subscribed) webhook is actually POSTed with the HMAC signature.
- [x] No webhook configured → logs and returns without error.
- [x] Tenant domain entity / schema / dispatcher agree on the `webhook` shape at compile time (no `as any`).
- [x] New tests pass; full suite green (301 passed); build green.

## Notes

Single-webhook-per-tenant was chosen as the canonical direction because the schema, the domain model, and `TenantWebhooksService` all already model it that way (issue option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
